### PR TITLE
Script-only validation

### DIFF
--- a/src/script/__tests/Spend.test.ts
+++ b/src/script/__tests/Spend.test.ts
@@ -15,8 +15,8 @@ import spendValid from './spend.valid.vectors'
 describe('Spend', () => {
   it('Successfully validates a P2PKH spend', async () => {
     const privateKey = new PrivateKey(1)
-    const publicKey = new Curve().g.mul(privateKey)
-    const hash = hash160(publicKey.encode(true)) as number[]
+    const publicKey = privateKey.toPublicKey()
+    const hash = publicKey.toHash()
     const p2pkh = new P2PKH()
     const lockingScript = p2pkh.lock(hash)
     const satoshis = new BigNumber(1)
@@ -49,9 +49,9 @@ describe('Spend', () => {
   })
   it('Fails to verify a P2PKH spend with the wrong key', async () => {
     const privateKey = new PrivateKey(1)
-    const publicKey = new Curve().g.mul(privateKey)
+    const publicKey = privateKey.toPublicKey()
     const wrongPrivateKey = new PrivateKey(2)
-    const hash = hash160(publicKey.encode(true)) as number[]
+    const hash = publicKey.toHash()
     const p2pkh = new P2PKH()
     const lockingScript = p2pkh.lock(hash)
     const satoshis = new BigNumber(1)

--- a/src/script/templates/P2PKH.ts
+++ b/src/script/templates/P2PKH.ts
@@ -19,7 +19,7 @@ export default class P2PKH implements ScriptTemplate {
    * @param {number[]} pubkeyhash - An array representing the public key hash.
    * @returns {LockingScript} - A P2PKH locking script.
    */
-  lock (pubkeyhash: number[]): LockingScript {
+  lock(pubkeyhash: number[]): LockingScript {
     return new LockingScript([
       { op: OP.OP_DUP },
       { op: OP.OP_HASH160 },
@@ -42,14 +42,14 @@ export default class P2PKH implements ScriptTemplate {
    * @param {boolean} anyoneCanPay - Flag indicating if the signature allows for other inputs to be added later.
    * @returns {Object} - An object containing the `sign` and `estimateLength` functions.
    */
-  unlock (
+  unlock(
     privateKey: PrivateKey,
     signOutputs: 'all' | 'none' | 'single' = 'all',
     anyoneCanPay: boolean = false
   ): {
-      sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>
-      estimateLength: () => Promise<106>
-    } {
+    sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>
+    estimateLength: () => Promise<106>
+  } {
     return {
       sign: async (tx: Transaction, inputIndex: number) => {
         let signatureScope = TransactionSignature.SIGHASH_FORKID

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -459,13 +459,13 @@ export default class Transaction {
   /**
    * Verifies the legitimacy of the Bitcoin transaction according to the rules of SPV by ensuring all the input transactions link back to valid block headers, the chain of spends for all inputs are valid, and the sum of inputs is not less than the sum of outputs.
    *
-   * @param chainTracker - An instance of ChainTracker, a Bitcoin block header tracker.
+   * @param chainTracker - An instance of ChainTracker, a Bitcoin block header tracker. If the value is set to 'scripts only', headers will not be verified.
    *
    * @returns Whether the transaction is valid according to the rules of SPV.
    */
-  async verify(chainTracker: ChainTracker): Promise<boolean> {
+  async verify(chainTracker: ChainTracker | 'scripts only'): Promise<boolean> {
     // If the transaction has a valid merkle path, verification is complete.
-    if (typeof this.merklePath === 'object') {
+    if (typeof this.merklePath === 'object' && chainTracker !== 'scripts only') {
       const proofValid = await this.merklePath.verify(
         this.id('hex') as string,
         chainTracker


### PR DESCRIPTION
Added a way to validate the scripts within a transaction graph without access to a block headers client.