### PR TITLE
Hash enc digest hex

### DIFF
--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -108,7 +108,7 @@ export default class PrivateKey extends BigNumber {
    * const privateKey = PrivateKey.fromRandom();
    * const signature = privateKey.sign('Hello, World!');
    */
-  sign (msg: number[] | string, enc?: 'hex', forceLowS: boolean = true, customK?: Function | BigNumber): Signature {
+  sign (msg: number[] | string, enc?: 'hex' | 'utf8', forceLowS: boolean = true, customK?: Function | BigNumber): Signature {
     const msgHash = new BigNumber(sha256(msg, enc), 16)
     return sign(msgHash, this, forceLowS, customK)
   }

--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -77,8 +77,9 @@ export default class PrivateKey extends BigNumber {
    * @param endian - The endianness provided. By default is 'big endian'. Ignored if number is BigNumber.
    *
    * @example
+   * import PrivateKey from './PrivateKey';
    * import BigNumber from './BigNumber';
-   * const bn = new BigNumber('123456', 10, 'be');
+   * const privKey = new PrivateKey(new BigNumber('123456', 10, 'be'));
    */
   constructor (
     number: BigNumber | number | string | number[] = 0,

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -100,7 +100,7 @@ export default class PublicKey extends Point {
    *
    * @param msg - The message to verify. It can be a string or an array of numbers.
    * @param sig - The Signature of the message that needs verification.
-   * @param enc - The encoding of the message. It defaults to 'hex'.
+   * @param enc - The encoding of the message. It defaults to 'utf8'.
    *
    * @returns Returns true if the signature is verified successfully, otherwise false.
    *
@@ -109,7 +109,7 @@ export default class PublicKey extends Point {
    * const mySignature = new Signature(...)
    * const isVerified = myPubKey.verify(myMessage, mySignature)
    */
-  verify (msg: number[] | string, sig: Signature, enc?: 'hex'): boolean {
+  verify (msg: number[] | string, sig: Signature, enc?: 'hex' | 'utf8'): boolean {
     const msgHash = new BigNumber(sha256(msg, enc), 16)
     return verify(msgHash, sig, this)
   }

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -53,6 +53,28 @@ export default class PublicKey extends Point {
   }
 
   /**
+   * @constructor
+   * @param x - A point or the x-coordinate of the point. May be a number, a BigNumber, a string (which will be interpreted as hex), a number array, or null. If null, an "Infinity" point is constructed.
+   * @param y - If x is not a point, the y-coordinate of the point, similar to x.
+   * @param isRed - A boolean indicating if the point is a member of the field of integers modulo the k256 prime. Default is true.
+   *
+   * @example
+   * new PublicKey(point1);
+   * new PublicKey('abc123', 'def456');
+   */
+  constructor (
+    x: Point | BigNumber | number | number[] | string | null,
+    y: BigNumber | number | number[] | string | null = null,
+    isRed: boolean = true
+  ) {
+    if (x instanceof Point) {
+      super(x.getX(), x.getY())
+    } else {
+      super(x, y, isRed)
+    }
+  }
+
+  /**
    * Derive a shared secret from a public key and a private key for use in symmetric encryption.
    * This method multiplies the public key (an instance of Point) with a private key.
    *

--- a/src/primitives/__tests/ECDSA.test.ts
+++ b/src/primitives/__tests/ECDSA.test.ts
@@ -4,7 +4,6 @@ import BigNumber from '../../../dist/cjs/src/primitives/BigNumber'
 //import { BigNumber } from '..'
 import Curve from '../../../dist/cjs/src/primitives/Curve'
 import Signature from '../../../dist/cjs/src/primitives/Signature'
-//import { Signature } from '..'
 
 const msg = new BigNumber('deadbeef', 16)
 const key = new BigNumber('1e5edd45de6d22deebef4596b80444ffcc29143839c1dce18db470e25b4be7b5', 16)

--- a/src/primitives/__tests/ECDSA.test.ts
+++ b/src/primitives/__tests/ECDSA.test.ts
@@ -1,7 +1,10 @@
 import * as ECDSA from '../../../dist/cjs/src/primitives/ECDSA'
+//import * as ECDSA from '../ECDSA'
 import BigNumber from '../../../dist/cjs/src/primitives/BigNumber'
+//import { BigNumber } from '..'
 import Curve from '../../../dist/cjs/src/primitives/Curve'
 import Signature from '../../../dist/cjs/src/primitives/Signature'
+//import { Signature } from '..'
 
 const msg = new BigNumber('deadbeef', 16)
 const key = new BigNumber('1e5edd45de6d22deebef4596b80444ffcc29143839c1dce18db470e25b4be7b5', 16)

--- a/src/primitives/__tests/ECDSA.test.ts
+++ b/src/primitives/__tests/ECDSA.test.ts
@@ -1,5 +1,4 @@
 import * as ECDSA from '../../../dist/cjs/src/primitives/ECDSA'
-//import * as ECDSA from '../ECDSA'
 import BigNumber from '../../../dist/cjs/src/primitives/BigNumber'
 import Curve from '../../../dist/cjs/src/primitives/Curve'
 import Signature from '../../../dist/cjs/src/primitives/Signature'

--- a/src/primitives/__tests/ECDSA.test.ts
+++ b/src/primitives/__tests/ECDSA.test.ts
@@ -1,7 +1,6 @@
 import * as ECDSA from '../../../dist/cjs/src/primitives/ECDSA'
 //import * as ECDSA from '../ECDSA'
 import BigNumber from '../../../dist/cjs/src/primitives/BigNumber'
-//import { BigNumber } from '..'
 import Curve from '../../../dist/cjs/src/primitives/Curve'
 import Signature from '../../../dist/cjs/src/primitives/Signature'
 

--- a/src/primitives/__tests/HMAC.test.ts
+++ b/src/primitives/__tests/HMAC.test.ts
@@ -47,12 +47,12 @@ describe('HMAC', function () {
     function test (opt): void {
       it(`should not fail at ${opt.name as string}`, function (): void {
         let h = new SHA256HMAC(opt.key)
-        expect(h.update(opt.msg, opt.msgEnc).digest('hex')).toEqual(opt.res)
+        expect(h.update(opt.msg, opt.msgEnc).digestHex()).toEqual(opt.res)
         h = h = new SHA256HMAC(opt.key)
         expect(h
           .update(opt.msg.slice(0, 10), opt.msgEnc)
           .update(opt.msg.slice(10), opt.msgEnc)
-          .digest('hex')).toEqual(opt.res)
+          .digestHex()).toEqual(opt.res)
       })
     }
   })

--- a/src/primitives/__tests/Hash.test.ts
+++ b/src/primitives/__tests/Hash.test.ts
@@ -11,13 +11,13 @@ describe('Hash', function () {
       const res = cases[i][1]
       const enc = cases[i][2]
 
-      let dgst = new Hash().update(msg, enc).digest('hex')
+      let dgst = new Hash().update(msg, enc).digestHex()
       expect(dgst).toEqual(res)
 
       // Split message
       dgst = new Hash().update(msg.slice(0, 2), enc)
         .update(msg.slice(2), enc)
-        .digest('hex')
+        .digestHex()
       expect(dgst).toEqual(res)
     }
   }


### PR DESCRIPTION
The significant change is to the hash classes / functions in regard to the enc (encoding) input argument.

This started from an incorrect comment on PublicKey.verify that the default encoding was 'hex' when it is in fact 'utf8'.

Following this into the hash classes it turned out that the same enc input parameter was being used to determine both the encoding of the input message (msg) AND the desired output type (number[] vs hex string).

As this needed resolving in any case, and it looked like very few tests were passing 'hex' encoding. This PR proposes to resolve the issue by:

1.  using the input enc parameter only for msg encoding
2. add an explicit 'utf8' option where missing on the type of the enc parameter
3. add an explicit `digestHex()` method to mirror `digest()` when a hex string output is desired.

Two tests were updated. All tests pass.
This is a breaking change to fix a broken API situation.