### PR TITLE
Tone bug 31

### DIFF
--- a/src/primitives/BigNumber.ts
+++ b/src/primitives/BigNumber.ts
@@ -552,15 +552,15 @@ export default class BigNumber {
   }
 
   /**
-   * The copy method creates and returns a separate identical copy of the BigNumber.
+   * The copy method copies the state of this BigNumber into an exsiting `dest` BigNumber.
    *
    * @method copy
-   * @param dest - The BigNumber instance that will be made into a copy.
+   * @param dest - The BigNumber instance that will be updated to become a copy.
    *
    * @example
    * const bn1 = new BigNumber('123456', 10, 'be');
    * const bn2 = new BigNumber();
-   * bn1.cop(bn2);
+   * bn1.copy(bn2);
    * // bn2 is now a BigNumber representing 123456
    */
   copy (dest: BigNumber): void {

--- a/src/primitives/__tests/bug-31.test.ts
+++ b/src/primitives/__tests/bug-31.test.ts
@@ -1,0 +1,33 @@
+//import { PrivateKey, PublicKey, Curve, Hash, BigNumber } from '..';
+import PublicKey from '../../../dist/cjs/src/primitives/PublicKey'
+//import { PrivateKey } from '..';
+import PrivateKey from '../../../dist/cjs/src/primitives/PrivateKey'
+import Curve from '../../../dist/cjs/src/primitives/Curve'
+import BigNumber from '../../../dist/cjs/src/primitives/BigNumber'
+
+describe("bug-31 tests", () => {
+
+    test("0", () => {
+        const c = new Curve()
+        const G = c.g
+        //const bn = new BigNumber(c.n + 12)
+        const bn = c.n.addn(12)
+        const sn = new BigNumber(12)
+        {
+            expect(() => new PrivateKey(bn.toHex(), 'hex', 'be', 'error')).toThrow("Input is out of field")
+        }
+        const o = PrivateKey.fromString(bn.toHex(), 'hex')
+        const os = PrivateKey.fromString(sn.toHex(), 'hex')
+        expect(o.cmp(os)).toBe(0)
+        const os2 = new PrivateKey(bn.toHex(), 'hex', 'be', 'nocheck')
+        expect(o.cmp(os2)).not.toBe(0)
+
+        const oWif = o.toWif()
+        expect(oWif).toBe('KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU79MFFcB1G')
+        const osWif = os.toWif()
+        expect(osWif).toBe('KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU79MFFcB1G')
+
+        expect(() => os2.toWif()).toThrow("Value is out of field")
+
+    })
+})


### PR DESCRIPTION
Changes to resolve two issues reported by sirdeggen ini BUG #31 

1. Default PrivateKey constructor now forces its input value, however provided, to the curve by applying mod N.

2. toWif method now forces binary value to 32 BE bytes before base 58 encoding.

Additional details:

The PrivateKey constructor now has an additional optional argument `modN` which controls the "in curve field" limiting behavior.

The options are:

- 'apply': the default, apply modN to input to guarantee a valid PrivateKey.
- 'error': if input is out of field throw Error('Input is out of field').
- 'nocheck': assumes input is in field or will become so prior to use as a private key.

The toWif method checks that the BigNumber value is in field and throws an error if not.