### PR TITLE
push(...x) fails for large array x values

### DIFF
--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -321,9 +321,12 @@ export class Writer {
   }
 
   toArray(): number[] {
-    const ret = []
+    let ret = []
     for (const x of this.bufs) {
-      ret.push(...x)
+      if (x.length < 65536)
+        ret.push(...x)
+      else
+        ret = ret.concat(x)
     }
     return ret
   }


### PR DESCRIPTION
Simple change that resolves max stack size error when using OP_PUSHDATA4 sized script values.