### PR TITLE
[fix] length must be that of the data, not the original argument.

### DIFF
--- a/src/script/templates/P2PKH.ts
+++ b/src/script/templates/P2PKH.ts
@@ -32,7 +32,7 @@ export default class P2PKH implements ScriptTemplate {
     return new LockingScript([
       { op: OP.OP_DUP },
       { op: OP.OP_HASH160 },
-      { op: pubkeyhash.length, data },
+      { op: data.length, data },
       { op: OP.OP_EQUALVERIFY },
       { op: OP.OP_CHECKSIG }
     ])


### PR DESCRIPTION
Resolves:

```javascript
import { PrivateKey, P2PKH, } from '@bsv/sdk'

function getLockingScriptFromPrivateKey (privateKey) {
  const script1 = new P2PKH().lock(privateKey.toPublicKey().toHash())
  const script2 = new P2PKH().lock(privateKey.toAddress())
  console.log({
    script1: script1.toHex(),
    script2: script2.toHex(),
  })
  console.log(script1.toHex() === script2.toHex())
  return new P2PKH().lock(privateKey.toPublicKey().toHash())
}


const p = PrivateKey.fromRandom()
getLockingScriptFromPrivateKey(p)
```