### PR TITLE
controversial stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BSV SDK
 
-BSV BLOCKCHAIN | Standard Development Kit for JavaScript and TypeScript
+BSV BLOCKCHAIN | Software Development Kit for JavaScript and TypeScript
 
 Welcome to the BSV Blockchain Libraries Project, the comprehensive TypeScript SDK designed to provide an updated and unified layer for developing scalable applications on the BSV Blockchain. This SDK addresses the limitations of previous tools by offering a fresh, peer-to-peer approach, adhering to SPV, and ensuring privacy and scalability.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bsv/sdk",
   "version": "1.0.14",
   "type": "module",
-  "description": "BSV Blockchain Standard Development Kit",
+  "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",
   "module": "dist/esm/mod.js",
   "types": "dist/types/mod.d.ts",


### PR DESCRIPTION
Apparently the correct term is Software Development Kit, although “Standard Development Kit” is a common mistake.