### PR TITLE
[fix] Enforce signature length in compact sigs

### DIFF
--- a/src/primitives/Signature.ts
+++ b/src/primitives/Signature.ts
@@ -282,8 +282,8 @@ export default class Signature {
       compactByte += 4
     }
     let arr = [compactByte]
-    arr = arr.concat(this.r.toArray())
-    arr = arr.concat(this.s.toArray())
+    arr = arr.concat(this.r.toArray('be', 32))
+    arr = arr.concat(this.s.toArray('be', 32))
     if (enc === 'hex') {
       return toHex(arr)
     } else if (enc === 'base64') {


### PR DESCRIPTION
Compact sigs require 32 bytes for r and s values. This is already checked in fromCompact, but was previously not explicitly set in toCompact, leading to some small signatures for randomly low r or s values.