### PR TITLE
refactor: add more static factory methods to HD class and use them in examples

### DIFF
--- a/docs/examples/EXAMPLE_HD_WALLETS.md
+++ b/docs/examples/EXAMPLE_HD_WALLETS.md
@@ -21,7 +21,7 @@ console.log(randomKey.toString())
 You can also import an existing key as follows:
 
 ```typescript
-const importedKey = new HD().fromString('xprv...')
+const importedKey = HD.fromString('xprv...')
 ```
 
 Now that you've generated or imported your key, you're ready to derive child keys.
@@ -31,7 +31,7 @@ Now that you've generated or imported your key, you're ready to derive child key
 BIP32 child keys can be derived from a key using the `.derive()` method. Here's a full example:
 
 ```typescript
-const key = new bsv.HD().fromString('xprv9s21ZrQH143K2vF2szsDFhrRehet4iHNCBPWprjymByU9mzN7n687qj3ULQ2YYXdNqFwhVSsKv9W9fM675whM9ATaYrmsLpykQSxMc6RN8V')
+const key = HD.fromString('xprv9s21ZrQH143K2vF2szsDFhrRehet4iHNCBPWprjymByU9mzN7n687qj3ULQ2YYXdNqFwhVSsKv9W9fM675whM9ATaYrmsLpykQSxMc6RN8V')
 const child = key.derive('m/0/1/2')
 console.log(child.toString())
 // 'xprv9yGx5dNDfq8pt1DJ9SFCK3gNFhjrL3kTqEj98oDs6xvfaUAUs3nyvVakQzwHAEMrc6gg1c3iaNCDubUruhX75gNHC7HAnFxHuxeiMVgLEqS'
@@ -44,7 +44,7 @@ Any of the standard derivation paths can be passed into the `.derive()` method.
 XPRIV keys can be converted to normal `PrivateKey` instances, and from there to WIF keys. XPUB keys can be converted to normal `PublicKey` instances, and from there to Bitcoin addresses. XPRIV keys can also be converted to XPUB keys:
 
 ```typescript
-const key = new bsv.HD().fromString('xprv9s21ZrQH143K2vF2szsDFhrRehet4iHNCBPWprjymByU9mzN7n687qj3ULQ2YYXdNqFwhVSsKv9W9fM675whM9ATaYrmsLpykQSxMc6RN8V')
+const key = HD.fromString('xprv9s21ZrQH143K2vF2szsDFhrRehet4iHNCBPWprjymByU9mzN7n687qj3ULQ2YYXdNqFwhVSsKv9W9fM675whM9ATaYrmsLpykQSxMc6RN8V')
 
 // Convert XPRIV to XPUB
 const xpubKey = key.toPublic()

--- a/src/compat/HD.ts
+++ b/src/compat/HD.ts
@@ -85,6 +85,16 @@ export default class HD {
   }
 
   /**
+   * Initializes the HD wallet from a given base58 encoded string.
+   * This method decodes a provided string to set up the HD wallet's properties.
+   * @param str - A base58 encoded string representing the wallet.
+   * @returns {HD} The new instance with properties set from the string.
+   */
+  public static fromString (str: string): HD {
+    return new this().fromString(str)
+  }
+
+  /**
      * Initializes the HD wallet from a given base58 encoded string.
      * This method decodes a provided string to set up the HD wallet's properties.
      * @param str - A base58 encoded string representing the wallet.
@@ -96,13 +106,13 @@ export default class HD {
   }
 
   /**
-     * Converts the HD wallet to a base58 encoded string.
-     * This method provides a string representation of the HD wallet's current state.
-     * @returns {string} A base58 encoded string of the HD wallet.
-     */
-  public toString (): string {
-    const bin = this.toBinary()
-    return toBase58Check(bin, [])
+   * Initializes the HD wallet from a seed.
+   * This method generates keys and other properties from a given seed, conforming to the BIP32 specification.
+   * @param bytes - An array of bytes representing the seed.
+   * @returns {HD} The current instance with properties set from the seed.
+   */
+  public static fromSeed (bytes: number[]): HD {
+    return new this().fromSeed(bytes)
   }
 
   /**
@@ -132,21 +142,21 @@ export default class HD {
   }
 
   /**
-     * Initializes the HD wallet from a seed.
-     * This method generates keys and other properties from a given seed, conforming to the BIP32 specification.
-     * @param bytes - An array of bytes representing the seed.
-     * @returns {HD} The current instance with properties set from the seed.
-     */
-  public static fromSeed (bytes: number[]): HD {
-    return new this().fromSeed(bytes)
+   * Initializes the HD wallet from a binary buffer.
+   * Parses a binary buffer to set up the wallet's properties.
+   * @param buf - A buffer containing the wallet data.
+   * @returns {HD} The new instance with properties set from the buffer.
+   */
+  public static fromBinary (buf: number[]): HD {
+    return new this().fromBinary(buf)
   }
 
   /**
-     * Initializes the HD wallet from a binary buffer.
-     * Parses a binary buffer to set up the wallet's properties.
-     * @param buf - A buffer containing the wallet data.
-     * @returns {HD} The current instance with properties set from the buffer.
-     */
+   * Initializes the HD wallet from a binary buffer.
+   * Parses a binary buffer to set up the wallet's properties.
+   * @param buf - A buffer containing the wallet data.
+   * @returns {HD} The current instance with properties set from the buffer.
+   */
   public fromBinary (buf: number[]): this {
     // Both pub and private extended keys are 78 buf
     if (buf.length !== 78) {
@@ -174,6 +184,16 @@ export default class HD {
     }
 
     return this
+  }
+
+  /**
+   * Converts the HD wallet to a base58 encoded string.
+   * This method provides a string representation of the HD wallet's current state.
+   * @returns {string} A base58 encoded string of the HD wallet.
+   */
+  public toString (): string {
+    const bin = this.toBinary()
+    return toBase58Check(bin, [])
   }
 
   /**

--- a/src/compat/__tests/HD.test.ts
+++ b/src/compat/__tests/HD.test.ts
@@ -1,5 +1,5 @@
 import HD from '../../../dist/cjs/src/compat/HD'
-import { fromBase58Check, toBase58Check, toArray, toHex } from '../../../dist/cjs/src/primitives/utils'
+import { fromBase58Check, toArray, toHex } from '../../../dist/cjs/src/primitives/utils'
 
 describe('HD', () => {
     it('should satisfy these basic API features', () => {
@@ -64,232 +64,231 @@ describe('HD', () => {
         let bip32
         bip32 = new HD()
         expect(bip32).toBeDefined()
-        expect(new HD().fromString(vector1mPrivate).toString()).toEqual(vector1mPrivate)
-        expect(new HD()
-            .fromString(new HD().fromString(vector1mPrivate).toString())
+        expect(HD.fromString(vector1mPrivate).toString()).toEqual(vector1mPrivate)
+        expect(HD.fromString(HD.fromString(vector1mPrivate).toString())
             .toString())
             .toEqual(vector1mPrivate)
     })
 
     it('should initialize test vector 1 from the extended public key', () => {
-        const bip32 = new HD().fromString(vector1mPublic)
+        const bip32 = HD.fromString(vector1mPublic)
         expect(bip32).toBeDefined()
     })
 
     it('should initialize test vector 1 from the extended private key', () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         expect(bip32).toBeDefined()
     })
 
     it('should get the extended public key from the extended private key for test vector 1', () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         expect(bip32.toPublic().toString()).toEqual(vector1mPublic)
     })
 
     it("should get m/0' ext. private key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector1m0hPrivate)
     })
 
     it("should get m/0' ext. public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector1m0hPublic)
     })
 
     it("should get m/0'/1 ext. private key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector1m0h1Private)
     })
 
     it("should get m/0'/1 ext. public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector1m0h1Public)
     })
 
     it("should get m/0'/1 ext. public key from m/0' public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'")
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/1')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector1m0h1Public)
     })
 
     it("should get m/0'/1/2h ext. private key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector1m0h12hPrivate)
     })
 
     it("should get m/0'/1/2h ext. public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector1m0h12hPublic)
     })
 
     it("should get m/0'/1/2h/2 ext. private key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'/2")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector1m0h12h2Private)
     })
 
     it("should get m/0'/1/2'/2 ext. public key from m/0'/1/2' public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'")
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/2')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector1m0h12h2Public)
     })
 
     it("should get m/0'/1/2h/2 ext. public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'/2")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector1m0h12h2Public)
     })
 
     it("should get m/0'/1/2h/2/1000000000 ext. private key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'/2/1000000000")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector1m0h12h21000000000Private)
     })
 
     it("should get m/0'/1/2h/2/1000000000 ext. public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'/2/1000000000")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector1m0h12h21000000000Public)
     })
 
     it("should get m/0'/1/2'/2/1000000000 ext. public key from m/0'/1/2'/2 public key from test vector 1", () => {
-        const bip32 = new HD().fromString(vector1mPrivate)
+        const bip32 = HD.fromString(vector1mPrivate)
         const child = bip32.derive("m/0'/1/2'/2")
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/1000000000')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector1m0h12h21000000000Public)
     })
 
     it('should initialize test vector 2 from the extended public key', () => {
-        const bip32 = new HD().fromString(vector2mPublic)
+        const bip32 = HD.fromString(vector2mPublic)
         expect(bip32).toBeDefined()
     })
 
     it('should initialize test vector 2 from the extended private key', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         expect(bip32).toBeDefined()
     })
 
     it('should get the extended public key from the extended private key for test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         expect(bip32.toPublic().toString()).toEqual(vector2mPublic)
     })
 
     it('should get m/0 ext. private key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive('m/0')
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector2m0Private)
     })
 
     it('should get m/0 ext. public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive('m/0')
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector2m0Public)
     })
 
     it('should get m/0 ext. public key from m public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive('m')
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/0')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector2m0Public)
     })
 
     it('should get m/0/2147483647h ext. private key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector2m02147483647hPrivate)
     })
 
     it('should get m/0/2147483647h ext. public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector2m02147483647hPublic)
     })
 
     it('should get m/0/2147483647h/1 ext. private key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector2m02147483647h1Private)
     })
 
     it('should get m/0/2147483647h/1 ext. public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector2m02147483647h1Public)
     })
 
     it('should get m/0/2147483647h/1 ext. public key from m/0/2147483647h public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'")
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/1')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector2m02147483647h1Public)
     })
 
     it('should get m/0/2147483647h/1/2147483646h ext. private key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1/2147483646'")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector2m02147483647h12147483646hPrivate)
     })
 
     it('should get m/0/2147483647h/1/2147483646h ext. public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1/2147483646'")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector2m02147483647h12147483646hPublic)
     })
 
     it('should get m/0/2147483647h/1/2147483646h/2 ext. private key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1/2147483646'/2")
         expect(child).toBeDefined()
         expect(child.toString()).toEqual(vector2m02147483647h12147483646h2Private)
     })
 
     it('should get m/0/2147483647h/1/2147483646h/2 ext. public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1/2147483646'/2")
         expect(child).toBeDefined()
         expect(child.toPublic().toString()).toEqual(vector2m02147483647h12147483646h2Public)
     })
 
     it('should get m/0/2147483647h/1/2147483646h/2 ext. public key from m/0/2147483647h/2147483646h public key from test vector 2', () => {
-        const bip32 = new HD().fromString(vector2mPrivate)
+        const bip32 = HD.fromString(vector2mPrivate)
         const child = bip32.derive("m/0/2147483647'/1/2147483646'")
-        const childPub = new HD().fromString(child.toPublic().toString())
+        const childPub = HD.fromString(child.toPublic().toString())
         const child2 = childPub.derive('m/2')
         expect(child2).toBeDefined()
         expect(child2.toPublic().toString()).toEqual(vector2m02147483647h12147483646h2Public)
@@ -297,8 +296,8 @@ describe('HD', () => {
 
     describe('#fromRandom', () => {
         it('should not return the same one twice', () => {
-            const bip32a = new HD().fromRandom()
-            const bip32b = new HD().fromRandom()
+            const bip32a = HD.fromRandom()
+            const bip32b = HD.fromRandom()
             expect(bip32a.toString()).not.toEqual(bip32b.toString())
         })
     })
@@ -314,7 +313,7 @@ describe('HD', () => {
     describe('#fromSeed', () => {
         it('should initialize a new Bip32 correctly from test vector 1 seed', () => {
             const hex = vector1master
-            const bip32 = new HD().fromSeed(toArray(hex, 'hex'))
+            const bip32 = HD.fromSeed(toArray(hex, 'hex'))
             expect(bip32).toBeDefined()
             expect(bip32.toString()).toEqual(vector1mPrivate)
             expect(bip32.toPublic().toString()).toEqual(vector1mPublic)
@@ -322,7 +321,7 @@ describe('HD', () => {
 
         it('should initialize a new Bip32 correctly from test vector 2 seed', () => {
             const hex = vector2master
-            const bip32 = new HD().fromSeed(toArray(hex, 'hex'))
+            const bip32 = HD.fromSeed(toArray(hex, 'hex'))
             expect(bip32).toBeDefined()
             expect(bip32.toString()).toEqual(vector2mPrivate)
             expect(bip32.toPublic().toString()).toEqual(vector2mPublic)
@@ -352,12 +351,12 @@ describe('HD', () => {
             const str =
                 'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi'
             const buf = fromBase58Check(str)
-            let bip32 = new HD().fromBinary([...buf.prefix, ...buf.data])
+            let bip32 = HD.fromBinary([...buf.prefix, ...buf.data])
             expect(bip32).toBeDefined()
             expect(bip32.toString()).toEqual(str)
             bip32 = bip32.toPublic()
             const xpub = bip32.toString()
-            bip32 = new HD().fromBinary(bip32.toBinary())
+            bip32 = HD.fromBinary(bip32.toBinary())
             expect(bip32.toString()).toEqual(xpub)
         })
     })
@@ -367,7 +366,7 @@ describe('HD', () => {
             const str =
                 'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi'
             const buf = fromBase58Check(str)
-            const bip32 = new HD().fromString(str)
+            const bip32 = HD.fromString(str)
             expect(toHex(bip32.toBinary())).toEqual(toHex([...buf.prefix, ...buf.data]))
         })
     })
@@ -376,7 +375,7 @@ describe('HD', () => {
         it('should make a bip32 from a string', () => {
             const str =
                 'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi'
-            const bip32 = new HD().fromString(str)
+            const bip32 = HD.fromString(str)
             expect(bip32).toBeDefined()
             expect(bip32.toString()).toEqual(str)
         })
@@ -396,7 +395,7 @@ describe('HD', () => {
 
     describe('#isPrivate', () => {
         it('should know if this bip32 is private', () => {
-            const bip32priv = new HD().fromRandom()
+            const bip32priv = HD.fromRandom()
             const bip32pub = bip32priv.toPublic()
             expect(bip32priv.isPrivate()).toEqual(true)
             expect(bip32pub.isPrivate()).toEqual(false)


### PR DESCRIPTION
HD class was not aligned with the rest the rest of the code.
It is counterintuitive to first create a new instance, then use factory method,
especially as there was already one static factory method.


What I propose is to add corresponding static factory method for each method `fromX` and use them in examples and tests.
Whats more, I made a small rearrangement of the methods to have all those factory methods next to each other.