### PR TITLE
[chore] remove redundant line

### DIFF
--- a/src/script/OP.ts
+++ b/src/script/OP.ts
@@ -213,7 +213,6 @@ const OP = {
 
 for (const name in OP) {
   OP[OP[name]] = name
-  OP[String(OP[name])] = name
 }
 
 export default OP


### PR DESCRIPTION
The line above does exactly the same thing (reverse index) because JavaScript automatically converts keys of objects to strings.