### PR TITLE
Add Transaction.parseScriptOffsets

### DIFF
--- a/src/transaction/__tests/Transaction.test.ts
+++ b/src/transaction/__tests/Transaction.test.ts
@@ -83,6 +83,26 @@ describe('Transaction', () => {
     })
   })
 
+  describe('#parseScriptOffsets', () => {
+      it('should match sliced scripts to parsed scripts', async () => {
+        const tx = Transaction.fromBinary(tx2buf)
+        expect(tx.id("hex")).toBe(tx2idhex)
+        const r = Transaction.parseScriptOffsets(tx2buf)
+        expect(r.inputs.length).toBe(2)
+        expect(r.outputs.length).toBe(2)
+        for (let vin = 0; vin < 2; vin++) {
+            const i = r.inputs[vin]
+            const script = tx2buf.slice(i.offset, i.length + i.offset)
+            expect(script).toEqual(tx.inputs[vin].unlockingScript?.toBinary())
+        }
+        for (let vout = 0; vout < 2; vout++) {
+            const o = r.outputs[vout]
+            const script = tx2buf.slice(o.offset, o.length + o.offset)
+            expect(script).toEqual(tx.outputs[vout].lockingScript?.toBinary())
+        }
+      })
+  })
+
   describe('#toHex', () => {
     it('should produce this known tx', () => {
       expect(Transaction.fromHex(txhex).toHex()).toEqual(txhex)


### PR DESCRIPTION
```
  /**
   * Since the validation of blockchain data is atomically transaction data validation,
   * any application seeking to validate data in output scripts must store the entire transaction as well.
   * Since the transaction data includes the output script data, saving a second copy of potentially
   * large scripts can bloat application storage requirements.
   * 
   * This function efficiently parses binary transaction data to determine the offsets and lengths of each script.
   * This supports the efficient retreival of script data from transaction data.
   * 
   * @param bin binary transaction data
   * @returns {
   *   inputs: { vin: number, offset: number, length: number }[]
   *   outputs: { vout: number, offset: number, length: number }[]
   * }
   */
  static parseScriptOffsets(bin: number[])
  ```