### PR TITLE
Addional input field sourceSatoshis to be used in fee calculation

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -47,6 +47,7 @@ export default interface TransactionInput {
     sourceTransaction?: Transaction;
     sourceTXID?: string;
     sourceOutputIndex: number;
+    sourceSatoshis?: number;
     unlockingScript?: UnlockingScript;
     unlockingScriptTemplate?: {
         sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>;

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -837,6 +837,7 @@ export default class Transaction {
     addOutput(output: TransactionOutput): void 
     updateMetadata(metadata: Record<string, any>): void 
     async fee(model?: FeeModel, changeDistribution: "equal" | "random" = "equal"): Promise<void> 
+    getFee(): number 
     async sign(): Promise<void> 
     async broadcast(broadcaster: Broadcaster = defaultBroadcaster()): Promise<BroadcastResponse | BroadcastFailure> 
     toBinary(): number[] 
@@ -990,6 +991,18 @@ Argument Details
 
 + **hex**
   + The hexadecimal string representation of the transaction BEEF.
+
+#### Method getFee
+
+Utility method that returns the current fee based on inputs and outputs
+
+```ts
+getFee(): number 
+```
+
+Returns
+
+The current transaction fee
 
 #### Method hash
 

--- a/src/script/templates/P2PKH.ts
+++ b/src/script/templates/P2PKH.ts
@@ -90,7 +90,8 @@ export default class P2PKH implements ScriptTemplate {
             'The input sourceTXID or sourceTransaction is required for transaction signing.'
           )
         }
-        sourceSatoshis ||= input.sourceTransaction?.outputs[input.sourceOutputIndex].satoshis || input.sourceSatoshis
+        sourceSatoshis ||= input.sourceTransaction?.outputs[input.sourceOutputIndex].satoshis
+        sourceSatoshis ||= input.sourceSatoshis
         if (!sourceSatoshis) {
           throw new Error(
             'The sourceSatoshis or input sourceTransaction is required for transaction signing.'

--- a/src/script/templates/P2PKH.ts
+++ b/src/script/templates/P2PKH.ts
@@ -90,7 +90,7 @@ export default class P2PKH implements ScriptTemplate {
             'The input sourceTXID or sourceTransaction is required for transaction signing.'
           )
         }
-        sourceSatoshis ||= input.sourceTransaction?.outputs[input.sourceOutputIndex].satoshis
+        sourceSatoshis ||= input.sourceTransaction?.outputs[input.sourceOutputIndex].satoshis || input.sourceSatoshis
         if (!sourceSatoshis) {
           throw new Error(
             'The sourceSatoshis or input sourceTransaction is required for transaction signing.'

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -309,12 +309,12 @@ export default class Transaction {
     // change = inputs - fee - non-change outputs
     let change = 0
     for (const input of this.inputs) {
-      if (typeof input.sourceSatoshis !== 'number' && typeof input.sourceTransaction !== 'object') {
+      if (typeof input.sourceTransaction !== 'object' && typeof input.sourceSatoshis !== 'number') {
         throw new Error('Source transactions or sourceSatoshis are required for all inputs during fee computation')
       }
-      change += typeof input.sourceSatoshis === 'number'
-        ? input.sourceSatoshis
-        : input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
+      change += input.sourceTransaction
+        ? input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
+        : input.sourceSatoshis
     }
     change -= fee
     let changeCount = 0

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -353,6 +353,25 @@ export default class Transaction {
   }
 
   /**
+   * Utility method that returns the current fee based on inputs and outputs
+   *
+   * @returns The current transaction fee
+   */
+  getFee (): number {
+    let totalIn = 0
+    for (const input of this.inputs) {
+      totalIn += input.sourceTransaction
+        ? input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
+        : input.sourceSatoshis || 0
+    }
+    let totalOut = 0
+    for (const output of this.outputs) {
+      totalOut += output.satoshis || 0
+    }
+    return totalIn - totalOut
+  }
+
+  /**
    * Signs a transaction, hydrating all its unlocking scripts based on the provided script templates where they are available.
    */
   async sign (): Promise<void> {

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -309,10 +309,12 @@ export default class Transaction {
     // change = inputs - fee - non-change outputs
     let change = 0
     for (const input of this.inputs) {
-      if (typeof input.sourceTransaction !== 'object') {
-        throw new Error('Source transactions are required for all inputs during fee computation')
+      if (typeof input.sourceSatoshis !== 'number' && typeof input.sourceTransaction !== 'object') {
+        throw new Error('Source transactions or sourceSatoshis are required for all inputs during fee computation')
       }
-      change += input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
+      change += typeof input.sourceSatoshis === 'number'
+        ? input.sourceSatoshis
+        : input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
     }
     change -= fee
     let changeCount = 0

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -360,6 +360,9 @@ export default class Transaction {
   getFee (): number {
     let totalIn = 0
     for (const input of this.inputs) {
+      if (typeof input.sourceTransaction !== 'object' && typeof input.sourceSatoshis !== 'number') {
+        throw new Error('Source transactions or sourceSatoshis are required for all inputs to calculate fee')
+      }
       totalIn += input.sourceTransaction
         ? input.sourceTransaction.outputs[input.sourceOutputIndex].satoshis
         : input.sourceSatoshis || 0

--- a/src/transaction/TransactionInput.ts
+++ b/src/transaction/TransactionInput.ts
@@ -17,8 +17,8 @@ import Transaction from './Transaction.js'
  *           that this input is spending. It is zero-based, indicating the position of the
  *           output in the array of outputs of the source transaction.
  * @property {number} [sourceSatoshis] - The amount of satoshis of the source transaction
- *           output that this input is spending, used for fee calculation and signing when source
- *           transaction is not present
+ *           output that this input is spending, used for fee calculation and signing when
+ *           source transaction is not present
  * @property {UnlockingScript} [unlockingScript] - Optional. The script that 'unlocks' the
  *           source output for spending. This script typically contains signatures and
  *           public keys that evidence the ownership of the output.

--- a/src/transaction/TransactionInput.ts
+++ b/src/transaction/TransactionInput.ts
@@ -17,7 +17,7 @@ import Transaction from './Transaction.js'
  *           that this input is spending. It is zero-based, indicating the position of the
  *           output in the array of outputs of the source transaction.
  * @property {number} [sourceSatoshis] - The amount of satoshis of the source transaction
- *           output that this input is spending, used for fee calculation when source
+ *           output that this input is spending, used for fee calculation and signing when source
  *           transaction is not present
  * @property {UnlockingScript} [unlockingScript] - Optional. The script that 'unlocks' the
  *           source output for spending. This script typically contains signatures and

--- a/src/transaction/TransactionInput.ts
+++ b/src/transaction/TransactionInput.ts
@@ -16,6 +16,9 @@ import Transaction from './Transaction.js'
  * @property {number} sourceOutputIndex - The index of the output in the source transaction
  *           that this input is spending. It is zero-based, indicating the position of the
  *           output in the array of outputs of the source transaction.
+ * @property {number} [sourceSatoshis] - The amount of satoshis of the source transaction
+ *           output that this input is spending, used for fee calculation when source
+ *           transaction is not present
  * @property {UnlockingScript} [unlockingScript] - Optional. The script that 'unlocks' the
  *           source output for spending. This script typically contains signatures and
  *           public keys that evidence the ownership of the output.
@@ -54,6 +57,7 @@ export default interface TransactionInput {
   sourceTransaction?: Transaction
   sourceTXID?: string
   sourceOutputIndex: number
+  sourceSatoshis?: number
   unlockingScript?: UnlockingScript
   unlockingScriptTemplate?: {
     sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>

--- a/src/transaction/__tests/Transaction.test.ts
+++ b/src/transaction/__tests/Transaction.test.ts
@@ -385,6 +385,7 @@ describe('Transaction', () => {
       })
       await tx.fee({ computeFee: async () => 10 })
       expect(tx.outputs[0].satoshis).toEqual(20000 - 10)
+      expect(tx.getFee()).toEqual(10)
     })
   })
 

--- a/src/transaction/__tests/Transaction.test.ts
+++ b/src/transaction/__tests/Transaction.test.ts
@@ -352,6 +352,40 @@ describe('Transaction', () => {
       expect(spendTx.outputs[1].satoshis).toEqual(983)
       expect(spendTx.outputs[2].satoshis).toEqual(983)
     })
+    it('Calculates fee for utxo based transaction', async () => {
+      const utxos = [ // WoC format utxos
+        {
+          height: 1600000,
+          tx_pos: 0,
+          tx_hash: '672dd6a93fa5d7ba6794e0bdf8b479440b95a55ec10ad3d9e03585ecb5628d8d',
+          value: 10000
+        },
+        {
+          height: 1600000,
+          tx_pos: 0,
+          tx_hash: 'f33505acf37a7726cc37d391bc6f889b8684ac2a2d581c4be2a4b1c8b46609bc',
+          value: 10000
+        },
+      ]
+      const priv = PrivateKey.fromRandom()
+      const tx = new Transaction()
+      utxos.forEach(utxo => {
+        const script = new P2PKH().lock(priv.toPublicKey().toHash())
+        tx.addInput({
+          sourceTXID: utxo.tx_hash,
+          sourceOutputIndex: utxo.tx_pos,
+          sourceSatoshis: utxo.value,
+          unlockingScriptTemplate: new P2PKH()
+            .unlock(priv, 'all', false, utxo.value, script)
+        })
+      })
+      tx.addOutput({
+        lockingScript: new P2PKH().lock(priv.toAddress()),
+        change: true
+      })
+      await tx.fee({ computeFee: async () => 10 })
+      expect(tx.outputs[0].satoshis).toEqual(20000 - 10)
+    })
   })
 
   describe('Broadcast', () => {


### PR DESCRIPTION
## Motivation

In my apps I usually work with UTXOs and keep them stored and recycle them etc.
This additional field `sourceSatoshis` on inputs allows for fee calculation to not require the source transaction anymore.
This allows to create transactions and calculate fees solely using UTXOs (for example fetched from WoC), I included an example in `Transactions.test.ts` file. 

Edit 
 * I since added a utility method `getFee()` to transactions that returns the current tx fee.
 * Also added support for input.sourceSatoshis on P2PKH.unlock() method