### PR TITLE
toAddress() string prefix support

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6597,10 +6597,10 @@ Argument Details
 Example
 
 ```ts
-const address = privKey.toAddress()
-const address = privKey.toAddress('mainnet')
-const testnetAddress = privKey.toAddress([0x6f])
-const testnetAddress = privKey.toAddress('testnet')
+const address = privkey.toAddress()
+const address = privkey.toAddress('mainnet')
+const testnetAddress = privkey.toAddress([0x6f])
+const testnetAddress = privkey.toAddress('testnet')
 ```
 
 #### Method toPublicKey

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6374,7 +6374,7 @@ export default class PrivateKey extends BigNumber {
     verify(msg: number[] | string, sig: Signature, enc?: "hex"): boolean 
     toPublicKey(): PublicKey 
     toWif(prefix: number[] = [128]): string 
-    toAddress(prefix: number[] = [0]): string 
+    toAddress(prefix: number[] | "testnet" = [0]): string 
     deriveSharedSecret(key: PublicKey): Point 
     deriveChild(publicKey: PublicKey, invoiceNumber: string): PrivateKey 
 }
@@ -6582,7 +6582,7 @@ Base58Check encodes the hash of the public key associated with this private key 
 Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
 
 ```ts
-toAddress(prefix: number[] = [0]): string 
+toAddress(prefix: number[] | "testnet" = [0]): string 
 ```
 
 Returns
@@ -6592,13 +6592,14 @@ Returns the address encoding associated with the hash of the public key associat
 Argument Details
 
 + **prefix**
-  + defaults to [0x00] for mainnet, set to [0x6f] for testnet.
+  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
 
 Example
 
 ```ts
 const address = pubkey.toAddress()
 const testnetAddress = pubkey.toAddress([0x6f])
+const testnetAddress = pubkey.toAddress('testnet')
 ```
 
 #### Method toPublicKey
@@ -6702,7 +6703,7 @@ export default class PublicKey extends Point {
     verify(msg: number[] | string, sig: Signature, enc?: "hex" | "utf8"): boolean 
     toDER(): string 
     toHash(enc?: "hex"): number[] | string 
-    toAddress(prefix: number[] = [0]): string 
+    toAddress(prefix: number[] | "testnet" = [0]): string 
     deriveChild(privateKey: PrivateKey, invoiceNumber: string): PublicKey 
     static fromMsgHashAndCompactSignature(msgHash: BigNumber, signature: number[] | string, enc?: "hex" | "base64"): PublicKey 
 }
@@ -6868,7 +6869,7 @@ Base58Check encodes the hash of the public key with a prefix to indicate locking
 Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
 
 ```ts
-toAddress(prefix: number[] = [0]): string 
+toAddress(prefix: number[] | "testnet" = [0]): string 
 ```
 
 Returns
@@ -6878,13 +6879,14 @@ Returns the address encoding associated with the hash of the public key.
 Argument Details
 
 + **prefix**
-  + defaults to [0x00] for mainnet, set to [0x6f] for testnet.
+  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
 
 Example
 
 ```ts
 const address = pubkey.toAddress()
 const testnetAddress = pubkey.toAddress([0x6f])
+const testnetAddress = pubkey.toAddress('testnet')
 ```
 
 #### Method toDER

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6597,10 +6597,10 @@ Argument Details
 Example
 
 ```ts
-const address = pubkey.toAddress()
-const address = pubkey.toAddress('mainnet')
-const testnetAddress = pubkey.toAddress([0x6f])
-const testnetAddress = pubkey.toAddress('testnet')
+const address = privKey.toAddress()
+const address = privKey.toAddress('mainnet')
+const testnetAddress = privKey.toAddress([0x6f])
+const testnetAddress = privKey.toAddress('testnet')
 ```
 
 #### Method toPublicKey

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -6374,7 +6374,7 @@ export default class PrivateKey extends BigNumber {
     verify(msg: number[] | string, sig: Signature, enc?: "hex"): boolean 
     toPublicKey(): PublicKey 
     toWif(prefix: number[] = [128]): string 
-    toAddress(prefix: number[] | "testnet" = [0]): string 
+    toAddress(prefix: number[] | string = [0]): string 
     deriveSharedSecret(key: PublicKey): Point 
     deriveChild(publicKey: PublicKey, invoiceNumber: string): PrivateKey 
 }
@@ -6582,7 +6582,7 @@ Base58Check encodes the hash of the public key associated with this private key 
 Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
 
 ```ts
-toAddress(prefix: number[] | "testnet" = [0]): string 
+toAddress(prefix: number[] | string = [0]): string 
 ```
 
 Returns
@@ -6592,12 +6592,13 @@ Returns the address encoding associated with the hash of the public key associat
 Argument Details
 
 + **prefix**
-  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
+  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the strings 'testnet' or 'mainnet'
 
 Example
 
 ```ts
 const address = pubkey.toAddress()
+const address = pubkey.toAddress('mainnet')
 const testnetAddress = pubkey.toAddress([0x6f])
 const testnetAddress = pubkey.toAddress('testnet')
 ```
@@ -6703,7 +6704,7 @@ export default class PublicKey extends Point {
     verify(msg: number[] | string, sig: Signature, enc?: "hex" | "utf8"): boolean 
     toDER(): string 
     toHash(enc?: "hex"): number[] | string 
-    toAddress(prefix: number[] | "testnet" = [0]): string 
+    toAddress(prefix: number[] | string = [0]): string 
     deriveChild(privateKey: PrivateKey, invoiceNumber: string): PublicKey 
     static fromMsgHashAndCompactSignature(msgHash: BigNumber, signature: number[] | string, enc?: "hex" | "base64"): PublicKey 
 }
@@ -6869,7 +6870,7 @@ Base58Check encodes the hash of the public key with a prefix to indicate locking
 Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
 
 ```ts
-toAddress(prefix: number[] | "testnet" = [0]): string 
+toAddress(prefix: number[] | string = [0]): string 
 ```
 
 Returns
@@ -6879,12 +6880,13 @@ Returns the address encoding associated with the hash of the public key.
 Argument Details
 
 + **prefix**
-  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
+  + defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the strings 'mainnet' or 'testnet'
 
 Example
 
 ```ts
 const address = pubkey.toAddress()
+const address = pubkey.toAddress('mainnet')
 const testnetAddress = pubkey.toAddress([0x6f])
 const testnetAddress = pubkey.toAddress('testnet')
 ```

--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -214,10 +214,10 @@ export default class PrivateKey extends BigNumber {
    * @returns Returns the address encoding associated with the hash of the public key associated with this private key.
    *
    * @example
-   * const address = privKey.toAddress()
-   * const address = privKey.toAddress('mainnet')
-   * const testnetAddress = privKey.toAddress([0x6f])
-   * const testnetAddress = privKey.toAddress('testnet')
+   * const address = privkey.toAddress()
+   * const address = privkey.toAddress('mainnet')
+   * const testnetAddress = privkey.toAddress([0x6f])
+   * const testnetAddress = privkey.toAddress('testnet')
    */
   toAddress (prefix: number[] | string = [0x00]): string {
     return this.toPublicKey().toAddress(prefix)

--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -214,10 +214,10 @@ export default class PrivateKey extends BigNumber {
    * @returns Returns the address encoding associated with the hash of the public key associated with this private key.
    *
    * @example
-   * const address = pubkey.toAddress()
-   * const address = pubkey.toAddress('mainnet')
-   * const testnetAddress = pubkey.toAddress([0x6f])
-   * const testnetAddress = pubkey.toAddress('testnet')
+   * const address = privKey.toAddress()
+   * const address = privKey.toAddress('mainnet')
+   * const testnetAddress = privKey.toAddress([0x6f])
+   * const testnetAddress = privKey.toAddress('testnet')
    */
   toAddress (prefix: number[] | string = [0x00]): string {
     return this.toPublicKey().toAddress(prefix)

--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -209,15 +209,16 @@ export default class PrivateKey extends BigNumber {
    * Base58Check encodes the hash of the public key associated with this private key with a prefix to indicate locking script type.
    * Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
    *
-   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet.
+   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
    *
    * @returns Returns the address encoding associated with the hash of the public key associated with this private key.
    *
    * @example
    * const address = pubkey.toAddress()
    * const testnetAddress = pubkey.toAddress([0x6f])
+   * const testnetAddress = pubkey.toAddress('testnet')
    */
-  toAddress (prefix: number[] = [0x00]): string {
+  toAddress (prefix: number[] | 'testnet' = [0x00]): string {
     return this.toPublicKey().toAddress(prefix)
   }
 

--- a/src/primitives/PrivateKey.ts
+++ b/src/primitives/PrivateKey.ts
@@ -209,16 +209,17 @@ export default class PrivateKey extends BigNumber {
    * Base58Check encodes the hash of the public key associated with this private key with a prefix to indicate locking script type.
    * Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
    *
-   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
+   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the strings 'testnet' or 'mainnet'
    *
    * @returns Returns the address encoding associated with the hash of the public key associated with this private key.
    *
    * @example
    * const address = pubkey.toAddress()
+   * const address = pubkey.toAddress('mainnet')
    * const testnetAddress = pubkey.toAddress([0x6f])
    * const testnetAddress = pubkey.toAddress('testnet')
    */
-  toAddress (prefix: number[] | 'testnet' = [0x00]): string {
+  toAddress (prefix: number[] | string = [0x00]): string {
     return this.toPublicKey().toAddress(prefix)
   }
 

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -156,12 +156,14 @@ export default class PublicKey extends Point {
    * const testnetAddress = pubkey.toAddress('testnet')
    */
   toAddress (prefix: number[] | string = [0x00]): string {
-    if (prefix === 'testnet' || prefix === 'test') {
-      prefix = [0x6f]
-    } else if (prefix === 'mainnet' || prefix === 'main') {
-      prefix = [0x00]
-    } else {
-      throw new Error(`Invalid prefix ${prefix}`)
+    if (typeof prefix === 'string') {
+      if (prefix === 'testnet' || prefix === 'test') {
+        prefix = [0x6f]
+      } else if (prefix === 'mainnet' || prefix === 'main') {
+        prefix = [0x00]
+      } else {
+        throw new Error(`Invalid prefix ${prefix}`)
+      }
     }
     return toBase58Check(this.toHash() as number[], prefix)
   }

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -145,15 +145,19 @@ export default class PublicKey extends Point {
    * Base58Check encodes the hash of the public key with a prefix to indicate locking script type.
    * Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
    *
-   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet.
+   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
    *
    * @returns Returns the address encoding associated with the hash of the public key.
    *
    * @example
    * const address = pubkey.toAddress()
    * const testnetAddress = pubkey.toAddress([0x6f])
+   * const testnetAddress = pubkey.toAddress('testnet')
    */
-  toAddress (prefix: number[] = [0x00]): string {
+  toAddress (prefix: number[] | 'testnet' = [0x00]): string {
+    if (prefix === 'testnet') {
+      prefix = [0x6f]
+    }
     return toBase58Check(this.toHash() as number[], prefix)
   }
 

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -145,18 +145,24 @@ export default class PublicKey extends Point {
    * Base58Check encodes the hash of the public key with a prefix to indicate locking script type.
    * Defaults to P2PKH for mainnet, otherwise known as a "Bitcoin Address".
    *
-   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the string 'testnet'
+   * @param prefix defaults to [0x00] for mainnet, set to [0x6f] for testnet or use the strings 'mainnet' or 'testnet'
    *
    * @returns Returns the address encoding associated with the hash of the public key.
    *
    * @example
    * const address = pubkey.toAddress()
+   * const address = pubkey.toAddress('mainnet')
    * const testnetAddress = pubkey.toAddress([0x6f])
    * const testnetAddress = pubkey.toAddress('testnet')
    */
-  toAddress (prefix: number[] | 'testnet' = [0x00]): string {
-    if (prefix === 'testnet') {
+  toAddress (prefix: number[] | string = [0x00]): string {
+    if (prefix === 'testnet' || prefix === 'test') {
       prefix = [0x6f]
+    }
+    else if (prefix === 'mainnet' || prefix === 'main') {
+      prefix = [0x00]
+    } else {
+      throw new Error(`Invalid prefix ${prefix}`)
     }
     return toBase58Check(this.toHash() as number[], prefix)
   }

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -158,8 +158,7 @@ export default class PublicKey extends Point {
   toAddress (prefix: number[] | string = [0x00]): string {
     if (prefix === 'testnet' || prefix === 'test') {
       prefix = [0x6f]
-    }
-    else if (prefix === 'mainnet' || prefix === 'main') {
+    } else if (prefix === 'mainnet' || prefix === 'main') {
       prefix = [0x00]
     } else {
       throw new Error(`Invalid prefix ${prefix}`)


### PR DESCRIPTION
A slight improvement to the API, allows string prefixes like 'testnet' on `privateKey.toAddress()` and `publicKey.toAddress()` methods.

Allows prefixes 'mainnet', 'testnet' and also the shorthand 'main' and 'test' to indentify the network.

Although the use of [0x6f] prefix is well documented, this makes the code less cryptic to read and write, works like the old bsv library, also included shorthand 'main' and 'test' as they are the network identifiers used in WhatsOnChain.