### PR TITLE
metanet script template

### DIFF
--- a/docs/script.md
+++ b/docs/script.md
@@ -76,6 +76,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 | |
 | --- |
 | [LockingScript](#class-lockingscript) |
+| [Metanet](#class-metanet) |
 | [P2PKH](#class-p2pkh) |
 | [RPuzzle](#class-rpuzzle) |
 | [Script](#class-script) |
@@ -758,6 +759,72 @@ Argument Details
   + The signature scope for outputs.
 + **anyoneCanPay**
   + Flag indicating if the signature allows for other inputs to be added later.
+
+</details>
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Variables](#variables)
+
+---
+### Class: Metanet
+
+Metanet class implementing ScriptTemplate.
+
+This class provides methods to create Metanet outputs from data. Only lock script is available.
+
+```ts
+export default class Metanet implements ScriptTemplate {
+    lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: "hex" | "utf8" | "base64"): LockingScript 
+    unlock(): {
+        sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>;
+        estimateLength: () => Promise<number>;
+    } 
+}
+```
+
+<details>
+
+<summary>Class Metanet Details</summary>
+
+#### Method lock
+
+Creates a Metanet output script
+
+```ts
+lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: "hex" | "utf8" | "base64"): LockingScript 
+```
+
+Returns
+
+- A Metanet locking script.
+
+Argument Details
+
++ **pubkey**
+  + the public key responsible for the metanet node
++ **parentTXID**
+  + the TXID of the parent metanet transaction or null for root node
++ **data**
+  + the output data, an array of metadata ending in data payload
++ **enc**
+  + The data encoding type, defaults to utf8.
+
+Example
+
+```ts
+// creates a root metanet return with 'subprotocol' and 'filename' metadata followed by data
+lock(pubkey, null, txid, ['subprotocol', 'filename', data ])
+```
+
+#### Method unlock
+
+Unlock method is not available for Metanet scripts, throws exception.
+
+```ts
+unlock(): {
+    sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>;
+    estimateLength: () => Promise<number>;
+} 
+```
 
 </details>
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -805,8 +805,6 @@ Argument Details
   + the TXID of the parent metanet transaction or null for root node
 + **data**
   + the output data, an array of metadata ending in data payload
-+ **enc**
-  + The data encoding type, defaults to utf8.
 
 Example
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -809,7 +809,7 @@ Argument Details
 Example
 
 ```ts
-// creates a root metanet return with 'subprotocol' and 'filename' metadata followed by data
+// creates a root metanet output with 'subprotocol' and 'filename' metadata followed by data
 lock(pubkey, null, txid, ['subprotocol', 'filename', data ])
 ```
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -773,7 +773,7 @@ This class provides methods to create Metanet outputs from data. Only lock scrip
 
 ```ts
 export default class Metanet implements ScriptTemplate {
-    lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: "hex" | "utf8" | "base64"): LockingScript 
+    lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = []): LockingScript 
     unlock(): {
         sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>;
         estimateLength: () => Promise<number>;
@@ -790,7 +790,7 @@ export default class Metanet implements ScriptTemplate {
 Creates a Metanet output script
 
 ```ts
-lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: "hex" | "utf8" | "base64"): LockingScript 
+lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = []): LockingScript 
 ```
 
 Returns

--- a/src/script/__tests/Script.test.ts
+++ b/src/script/__tests/Script.test.ts
@@ -1,8 +1,9 @@
 import Script from '../../../dist/cjs/src/script/Script'
 import PrivateKey from '../../../dist/cjs/src/primitives/PrivateKey'
 import P2PKH from '../../../dist/cjs/src/script/templates/P2PKH'
+import Metanet from '../../../dist/cjs/src/script/templates/Metanet'
 import OP from '../../../dist/cjs/src/script/OP'
-import { toHex } from '../../../dist/cjs/src/primitives/utils'
+import { toHex, toUTF8, toArray } from '../../../dist/cjs/src/primitives/utils'
 
 import scriptInvalid from './script.invalid.vectors'
 import scriptValid from './script.valid.vectors'
@@ -397,6 +398,25 @@ describe('Script', () => {
         const strB = Script.fromHex(a[1]).toASM()
         expect(Script.fromASM(strB).toASM()).toEqual(strB)
       })
+    })
+  })
+
+  describe('Metanet template', () => {
+    it('creates metanet output', () => {
+      const priv = PrivateKey.fromRandom()
+      const script = new Metanet().lock(priv.toPublicKey(), null, ['subprotocol', 'data'])
+      const tokens = script.toASM().split(' ')
+      expect(tokens[0]).toEqual('OP_0')
+      expect(tokens[1]).toEqual('OP_RETURN')
+      expect(toUTF8(toArray(tokens[2], 'hex'))).toEqual('meta')
+      expect(tokens[3]).toEqual(priv.toPublicKey().toString())
+      expect(toUTF8(toArray(tokens[4], 'hex'))).toEqual('null')
+      expect(toUTF8(toArray(tokens[5], 'hex'))).toEqual('subprotocol')
+      expect(toUTF8(toArray(tokens[6], 'hex'))).toEqual('data')
+    })
+
+    it('fails to create metanet input', () => {
+      expect(() => new Metanet().unlock()).toThrow()
     })
   })
 })

--- a/src/script/__tests/Script.test.ts
+++ b/src/script/__tests/Script.test.ts
@@ -409,7 +409,7 @@ describe('Script', () => {
       expect(tokens[0]).toEqual('OP_0')
       expect(tokens[1]).toEqual('OP_RETURN')
       expect(toUTF8(toArray(tokens[2], 'hex'))).toEqual('meta')
-      expect(tokens[3]).toEqual(priv.toPublicKey().toString())
+      expect(toUTF8(toArray(tokens[3], 'hex'))).toEqual(priv.toPublicKey().toString())
       expect(toUTF8(toArray(tokens[4], 'hex'))).toEqual('null')
       expect(toUTF8(toArray(tokens[5], 'hex'))).toEqual('subprotocol')
       expect(toUTF8(toArray(tokens[6], 'hex'))).toEqual('data')

--- a/src/script/templates/Metanet.ts
+++ b/src/script/templates/Metanet.ts
@@ -1,0 +1,64 @@
+import OP from '../OP.js'
+import ScriptTemplate from '../ScriptTemplate.js'
+import LockingScript from '../LockingScript.js'
+import PublicKey from '../../primitives/PublicKey.js'
+import UnlockingScript from '../UnlockingScript.js'
+import Transaction from '../../transaction/Transaction.js'
+import { toArray } from '../../primitives/utils.js'
+
+/**
+ * Metanet class implementing ScriptTemplate.
+ *
+ * This class provides methods to create Metanet outputs from data. Only lock script is available.
+ */
+export default class Metanet implements ScriptTemplate {
+  /**
+   * Creates a Metanet output script
+   *
+   * @param {PublicKey} pubkey the public key responsible for the metanet node
+   * @param {string} parentTXID the TXID of the parent metanet transaction or null for root node
+   * @param {string[]} data the output data, an array of metadata ending in data payload
+   * @param {'hex' | 'utf8' | 'base64'} enc The data encoding type, defaults to utf8.
+   * @returns {LockingScript} - A Metanet locking script.
+   *
+   * @example
+   * // creates a root metanet return with 'subprotocol' and 'filename' metadata followed by data
+   * lock(pubkey, null, txid, ['subprotocol', 'filename', data ])
+   */
+  lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: 'hex' | 'utf8' | 'base64'): LockingScript {
+    const script : {op: number, data? }[] = [
+      { op: OP.OP_FALSE },
+      { op: OP.OP_RETURN }
+    ]
+
+    const fields = [
+      toArray('meta'),
+      toArray(pubkey.toString(), 'hex'),
+      parentTXID ? toArray(parentTXID, 'hex') : toArray('null')
+    ]
+
+    if (typeof data === 'string') {
+      data = [data]
+    }
+
+    for (const entry of data) {
+      fields.push(toArray(entry, enc))
+    }
+
+    for (const field of fields) {
+      script.push({ op: field.length, data: field })
+    }
+
+    return new LockingScript(script)
+  }
+
+  /**
+   * Unlock method is not available for Metanet scripts, throws exception.
+   */
+  unlock(): {
+    sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>
+    estimateLength: () => Promise<number>
+  } {
+    throw new Error('Unlock is not supported for Metanet scripts')
+  }
+}

--- a/src/script/templates/Metanet.ts
+++ b/src/script/templates/Metanet.ts
@@ -25,28 +25,20 @@ export default class Metanet implements ScriptTemplate {
    * // creates a root metanet return with 'subprotocol' and 'filename' metadata followed by data
    * lock(pubkey, null, txid, ['subprotocol', 'filename', data ])
    */
-  lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = [], enc?: 'hex' | 'utf8' | 'base64'): LockingScript {
+  lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = []): LockingScript {
     const script : {op: number, data? }[] = [
       { op: OP.OP_FALSE },
       { op: OP.OP_RETURN }
     ]
 
     const fields = [
-      toArray('meta'),
-      toArray(pubkey.toString(), 'hex'),
-      parentTXID ? toArray(parentTXID, 'hex') : toArray('null')
-    ]
-
-    if (typeof data === 'string') {
-      data = [data]
-    }
-
-    for (const entry of data) {
-      fields.push(toArray(entry, enc))
-    }
+      'meta',
+      pubkey.toString(),
+      parentTXID || 'null'
+    ].concat(data)
 
     for (const field of fields) {
-      script.push({ op: field.length, data: field })
+      script.push({ op: field.length, data: toArray(field) })
     }
 
     return new LockingScript(script)

--- a/src/script/templates/Metanet.ts
+++ b/src/script/templates/Metanet.ts
@@ -21,7 +21,7 @@ export default class Metanet implements ScriptTemplate {
    * @returns {LockingScript} - A Metanet locking script.
    *
    * @example
-   * // creates a root metanet return with 'subprotocol' and 'filename' metadata followed by data
+   * // creates a root metanet output with 'subprotocol' and 'filename' metadata followed by data
    * lock(pubkey, null, txid, ['subprotocol', 'filename', data ])
    */
   lock(pubkey: PublicKey, parentTXID: string | null, data: string[] | string = []): LockingScript {

--- a/src/script/templates/Metanet.ts
+++ b/src/script/templates/Metanet.ts
@@ -18,7 +18,6 @@ export default class Metanet implements ScriptTemplate {
    * @param {PublicKey} pubkey the public key responsible for the metanet node
    * @param {string} parentTXID the TXID of the parent metanet transaction or null for root node
    * @param {string[]} data the output data, an array of metadata ending in data payload
-   * @param {'hex' | 'utf8' | 'base64'} enc The data encoding type, defaults to utf8.
    * @returns {LockingScript} - A Metanet locking script.
    *
    * @example

--- a/src/script/templates/Metanet.ts
+++ b/src/script/templates/Metanet.ts
@@ -36,7 +36,7 @@ export default class Metanet implements ScriptTemplate {
       parentTXID || 'null'
     ].concat(data)
 
-    for (const field of fields) {
+    for (const field of fields.filter(Boolean)) {
       script.push({ op: field.length, data: toArray(field) })
     }
 

--- a/src/script/templates/index.ts
+++ b/src/script/templates/index.ts
@@ -1,2 +1,3 @@
 export { default as P2PKH } from './P2PKH.js'
 export { default as RPuzzle } from './RPuzzle.js'
+export { default as Metanet } from './Metanet.js'


### PR DESCRIPTION
Another PR related to #68, this time a helper for Metanet outputs.

Please note that I am encoding all fields after OP_RETURN from utf8 to hex including the txid and publickey, I am not sure this is correct but usually the whole script after OP_RETURN is encoded. I previously didn't encode them a second time, can revert to that.