### PR TITLE
Improve JSON content type detection

### DIFF
--- a/src/transaction/broadcasters/__tests/ARC.test.ts
+++ b/src/transaction/broadcasters/__tests/ARC.test.ts
@@ -189,7 +189,7 @@ describe('ARC Broadcaster', () => {
       headers: {
         get(key: string) {
           if (key === 'Content-Type') {
-            return 'application/json'
+            return 'application/json; charset=UTF-8'
           }
         }
       },
@@ -205,7 +205,7 @@ describe('ARC Broadcaster', () => {
           statusCode: response.status,
           statusMessage: response.status == 200 ? 'OK' : 'Bad request',
           headers: {
-            'content-type': 'application/json'
+            'content-type': 'application/json; charset=UTF-8'
           },
           on: (event, handler) => {
             if (event === 'data') handler(JSON.stringify(response.data))

--- a/src/transaction/http/FetchHttpClient.ts
+++ b/src/transaction/http/FetchHttpClient.ts
@@ -38,7 +38,7 @@ export class FetchHttpClient implements HttpClient {
 
     const res = await this.fetch(url, fetchOptions);
     const mediaType = res.headers.get('Content-Type');
-    const data = mediaType === 'application/json' ? await res.json() : await res.text();
+    const data = mediaType.startsWith('application/json') ? await res.json() : await res.text();
 
     return {
       ok: res.ok,

--- a/src/transaction/http/NodejsHttpClient.ts
+++ b/src/transaction/http/NodejsHttpClient.ts
@@ -32,7 +32,7 @@ export class NodejsHttpClient implements HttpClient {
         res.on('end', () => {
           const ok = res.statusCode >= 200 && res.statusCode <= 299;
           const mediaType = res.headers['content-type'];
-          const data = body && mediaType === 'application/json' ? JSON.parse(body) : body;
+          const data = body && mediaType.startsWith('application/json') ? JSON.parse(body) : body;
           resolve({
             status: res.statusCode,
             statusText: res.statusMessage,


### PR DESCRIPTION
Responses from latest version of ARC weren't parsed properly because their returned content-type header is `application/json; charset=UTF-8` and ts-sdk was only checking for `=== 'application/json'`

This resulted in an incorrect return value for `tx.broadcast()` when using the default broadcaster:
```js
{ status: 'success', txid: undefined, message: 'undefined undefined' }
```