### PR TITLE
removed unnecessary Buffer.from in pbkdf2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.1.5 - 2024-06-11](#115---2024-06-11)
 - [1.1.4 - 2024-05-10](#114---2024-05-10)
 - [1.1.0 - 2024-05-06](#110---2024-05-06)
 - [1.0.0 - 2024-02-10](#100---2024-02-10)
@@ -30,6 +31,10 @@ All notable changes to this project will be documented in this file. The format 
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
 
 ---
+
+## [1.1.5] - 2024-06-11
+### Fixed
+- Unnecessary `Buffer.from` in pbkdf2 function has been removed.
 
 ## [1.1.4] - 2024-05-10
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/Hash.ts
+++ b/src/primitives/Hash.ts
@@ -1429,7 +1429,6 @@ export function pbkdf2 (password: number[], salt: number[], iterations: number, 
   }
   const DK = new Array(keylen)
   const block1 = [...salt, 0, 0, 0, 0]
-  const s = Buffer.from('hello')
 
   let destPos = 0
   const hLen = 64


### PR DESCRIPTION
## Description of Changes

In `4-chain` team we've been trying to use `ts-sdk` along with [spv-wallet-js-client](https://github.com/bitcoin-sv/spv-wallet-js-client) for `react-native` **mobile application**.

We faced an issue with `Buffer` during `xPriv` creation:
```
[ReferenceError: Property 'Buffer' doesn't exist]
```

We discovered that when we call `mnemonic.toSeed()`, the function`pbkdf2` is internally called. 
And right here in the `pbkdf2` function we've found an unnecessary `Buffer.from` call that creates an unused local variable `s`.

After commented out this line locally - the entire functionality began working on mobile device. 