### PR TITLE
Tone feat req99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.1.9] - 2024-06-28
+### Fixed
+ARC Broadcaster correctly parses status -> code, details -> description. Adds txid to error response if provided.
 
 ## [1.1.8] - 2024-06-19
-
 ### Added
 TOTP class which allows the generation of time based pass codes. Use varies but originally included for validating shared secrets between remote counterparties over a secure channel.
 

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -124,6 +124,7 @@ Defines the structure of a failed broadcast response.
 export interface BroadcastFailure {
     status: "error";
     code: string;
+    txid?: string;
     description: string;
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/transaction/Broadcaster.ts
+++ b/src/transaction/Broadcaster.ts
@@ -20,11 +20,13 @@ export interface BroadcastResponse {
  * @interface
  * @property {string} status - The status of the response, indicating an error.
  * @property {string} code - A machine-readable error code representing the type of error encountered.
+ * @property {string} txid - The transaction ID of the broadcasted transaction.
  * @property {string} description - A detailed description of the error.
  */
 export interface BroadcastFailure {
   status: 'error'
   code: string
+  txid?: string
   description: string
 }
 

--- a/src/transaction/broadcasters/ARC.ts
+++ b/src/transaction/broadcasters/ARC.ts
@@ -106,18 +106,25 @@ export default class ARC implements Broadcaster {
           message: `${txStatus} ${extraInfo}`
         }
       } else {
+        const st = typeof response.status
         const r: BroadcastFailure = {
           status: 'error',
-          code: response.status.toString() ?? 'ERR_UNKNOWN',
+          code: st === 'number' || st === 'string' ? response.status.toString() : 'ERR_UNKNOWN',
           description: 'Unknown error'
         }
-        if (typeof response.data === 'string') {
+        let d = response.data
+        if (typeof d === 'string') {
           try {
-            const data = JSON.parse(response.data)
-            if (typeof data.detail === 'string') {
-              r.description = data.detail
-            }
-          } catch {}
+            d = JSON.parse(response.data)
+          } catch { }
+        }
+        if (typeof d === 'object') {
+          if (typeof d.txid === 'string') {
+            r.txid = d.txid
+          }
+          if (typeof d.detail === 'string') {
+            r.description = d.detail
+          }
         }
         return r
       }

--- a/src/transaction/broadcasters/__tests/ARC.test.ts
+++ b/src/transaction/broadcasters/__tests/ARC.test.ts
@@ -181,6 +181,29 @@ describe('ARC Broadcaster', () => {
     })
   })
 
+  it('handles error 460', async () => {
+    // Model the actual response format received from...
+    //const URL = 'https://arc.taal.com'
+    //const apiKey = 'mainnet_9596de07e92300c6287e4393594ae39c'
+    //const arc = new ARC(URL, apiKey)
+
+    const mockFetch = mockedFetch({
+      status: 460,
+      data: {
+        status: 460,
+        detail: 'Transaction is not in extended format, missing input scripts',
+        txid: 'd21633ba23f70118185227be58a63527675641ad37967e2aa461559f577aec43'
+      }
+    })
+
+    const broadcaster = new ARC(URL, {httpClient: new FetchHttpClient(mockFetch)})
+    const response = await broadcaster.broadcast(transaction)
+    expect(response.status).toBe('error')
+    expect(response.code).toBe('460')
+    expect(response.description).toBe('Transaction is not in extended format, missing input scripts')
+    expect(response.txid).toBe('d21633ba23f70118185227be58a63527675641ad37967e2aa461559f577aec43')
+  })
+
   function mockedFetch(response) {
     return jest.fn().mockResolvedValue({
       ok: response.status === 200,
@@ -223,4 +246,3 @@ describe('ARC Broadcaster', () => {
     return https
   }
 })
-


### PR DESCRIPTION
## Description of Changes

ARC.ts
ARC broadcaster was not extracting error details into description property, status into code property in all cases.

ARC.test.ts
updated to test broadcast error 460 property extraction.

## Linked Issues / Tickets

Closes Feature Request #99

## Testing Procedure

New test 'handles error 460' initially called live ARC service to obtain actual error response data format.
This was then captured as a static test with the live format hard wired.

## Checklist:

- [ x] I have performed a self-review of my own code
- [ n/a] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have updated `CHANGELOG.md` with my changes
- [ x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged