### PR TITLE
fix sourceTXID as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Removed
 
 ### Fixed
+- Utxo.fromUtxo now correctly sets sourceTXID on the input it returns.
+- Transaction.toBinary and Transaction.verify now check first if a sourceTXID is populated and use that before falling back to sourceTransaction.id()/sourceTransaction.hash().
 
 ### Security
 

--- a/src/compat/Utxo.ts
+++ b/src/compat/Utxo.ts
@@ -48,6 +48,7 @@ export default function fromUtxo (utxo: jsonUtxo, unlockingScriptTemplate: {
   }
   return {
     sourceTransaction,
+    sourceTXID: utxo.txid,
     sourceOutputIndex: utxo.vout,
     unlockingScriptTemplate,
     sequence: 0xFFFFFFFF

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -488,7 +488,7 @@ export default class Transaction {
     writer.writeUInt32LE(this.version)
     writer.writeVarIntNum(this.inputs.length)
     for (const i of this.inputs) {
-      if (typeof i.sourceTransaction !== 'undefined') {
+      if (typeof i.sourceTXID === 'undefined') {
         writer.write(i.sourceTransaction.hash() as number[])
       } else {
         writer.writeReverse(toArray(i.sourceTXID, 'hex'))
@@ -675,8 +675,11 @@ export default class Transaction {
       }
       const otherInputs = [...this.inputs]
       otherInputs.splice(i, 1)
+      if (typeof input.sourceTXID === 'undefined') {
+        input.sourceTXID = input.sourceTransaction.id('hex')
+      }
       const spend = new Spend({
-        sourceTXID: input.sourceTransaction.id('hex'),
+        sourceTXID: input.sourceTXID,
         sourceOutputIndex: input.sourceOutputIndex,
         lockingScript: sourceOutput.lockingScript,
         sourceSatoshis: sourceOutput.satoshis,


### PR DESCRIPTION
## Description of Changes

When using `Utxo.fromUtxo`, sourceTXID was not being set. This causes cascading issue when trying to sign a transaction, serialize it, or calculating fees. I've included two updates. 

1. `Utxo.fromUtxo` now sets `sourceTXID` on the input it returns.
2. `Transaction.toBinary` and `Transaction.verify` now check first if a sourceTXID is populated and uses that before falling back to `sourceTransaction.id()`/`sourceTransaction.hash()`

## Linked Issues / Tickets

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged