### PR TITLE
[ Change ] pubkey.toDER() defaults to number[] rather than string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
+- Added some convenience functions for toDER and fromDER on the point and pubkey classes where missing.
 
 ### Changed
+- In the PublicKey class pubkey.toDER() to defaults to return a number[] rather than string. If a string is desired .toString() or .toDER('hex') have equivalent functionality.
 
 ### Deprecated
 

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -5349,6 +5349,7 @@ export default class Point extends BasePoint {
     x: BigNumber | null;
     y: BigNumber | null;
     inf: boolean;
+    static fromDER(bytes: number[]): Point 
     static fromString(str: string): Point 
     static fromX(x: BigNumber | number | number[] | string, odd: boolean): Point 
     static fromJSON(obj: string | any[], isRed: boolean): Point 
@@ -5560,6 +5561,38 @@ Example
 const p1 = new Point(5, 20);
 const p2 = new Point(5, 20);
 const areEqual = p1.eq(p2); // returns true
+```
+
+#### Method fromDER
+
+Creates a point object from a given Array. These numbers can represent coordinates in hex format, or points
+in multiple established formats.
+The function verifies the integrity of the provided data and throws errors if inconsistencies are found.
+
+```ts
+static fromDER(bytes: number[]): Point 
+```
+
+Returns
+
+Returns a new point representing the given string.
+
+Argument Details
+
++ **bytes**
+  + The point representation number array.
+
+Throws
+
+`Error` If the point number[] value has a wrong length.
+
+`Error` If the point format is unknown.
+
+Example
+
+```ts
+const derPoint = [ 2, 18, 123, 108, 125, 83, 1, 251, 164, 214, 16, 119, 200, 216, 210, 193, 251, 193, 129, 67, 97, 146, 210, 216, 77, 254, 18, 6, 150, 190, 99, 198, 128 ];
+const point = Point.fromDER(derPoint);
 ```
 
 #### Method fromJSON
@@ -6716,10 +6749,11 @@ The class comes with static methods to generate PublicKey instances from private
 export default class PublicKey extends Point {
     static fromPrivateKey(key: PrivateKey): PublicKey 
     static fromString(str: string): PublicKey 
+    static fromDER(bytes: number[]): PublicKey 
     constructor(x: Point | BigNumber | number | number[] | string | null, y: BigNumber | number | number[] | string | null = null, isRed: boolean = true) 
     deriveSharedSecret(priv: PrivateKey): Point 
     verify(msg: number[] | string, sig: Signature, enc?: "hex" | "utf8"): boolean 
-    toDER(): string 
+    toDER(enc?: "hex" | undefined): string 
     toHash(enc?: "hex"): number[] | string 
     toAddress(prefix: number[] | string = [0]): string 
     deriveChild(privateKey: PrivateKey, invoiceNumber: string): PublicKey 
@@ -6799,6 +6833,29 @@ Example
 ```ts
 const myPrivKey = new PrivateKey(...)
 const sharedSecret = myPubKey.deriveSharedSecret(myPrivKey)
+```
+
+#### Method fromDER
+
+Static factory method to create a PublicKey instance from a number array.
+
+```ts
+static fromDER(bytes: number[]): PublicKey 
+```
+
+Returns
+
+Returns the PublicKey created from the number array.
+
+Argument Details
+
++ **bytes**
+  + A number array representing a public key.
+
+Example
+
+```ts
+const myPubKey = PublicKey.fromString("03....")
 ```
 
 #### Method fromMsgHashAndCompactSignature
@@ -6913,7 +6970,7 @@ const testnetAddress = pubkey.toAddress('testnet')
 Encode the public key to DER (Distinguished Encoding Rules) format.
 
 ```ts
-toDER(): string 
+toDER(enc?: "hex" | undefined): string 
 ```
 
 Returns

--- a/src/primitives/Point.ts
+++ b/src/primitives/Point.ts
@@ -22,26 +22,23 @@ export default class Point extends BasePoint {
   inf: boolean
 
   /**
-   * Creates a point object from a given string. This string can represent coordinates in hex format, or points
+   * Creates a point object from a given Array. These numbers can represent coordinates in hex format, or points
    * in multiple established formats.
    * The function verifies the integrity of the provided data and throws errors if inconsistencies are found.
    *
-   * @method fromString
+   * @method fromDER
    * @static
-   * @param str - The point representation string.
+   * @param bytes - The point representation number array.
    * @returns Returns a new point representing the given string.
-   * @throws `Error` If the point string value has a wrong length.
+   * @throws `Error` If the point number[] value has a wrong length.
    * @throws `Error` If the point format is unknown.
    *
    * @example
-   * const pointStr = 'abcdef';
-   * const point = Point.fromString(pointStr);
+   * const derPoint = [ 2, 18, 123, 108, 125, 83, 1, 251, 164, 214, 16, 119, 200, 216, 210, 193, 251, 193, 129, 67, 97, 146, 210, 216, 77, 254, 18, 6, 150, 190, 99, 198, 128 ];
+   * const point = Point.fromDER(derPoint);
    */
-  static fromString (str: string): Point {
-    const bytes = toArray(str, 'hex')
-
+  static fromDER (bytes: number[]): Point {
     const len = 32
-
     // uncompressed, hybrid-odd, hybrid-even
     if ((bytes[0] === 0x04 || bytes[0] === 0x06 || bytes[0] === 0x07) &&
       bytes.length - 1 === 2 * len) {
@@ -66,6 +63,28 @@ export default class Point extends BasePoint {
       return Point.fromX(bytes.slice(1, 1 + len), bytes[0] === 0x03)
     }
     throw new Error('Unknown point format')
+  }
+
+  /**
+   * Creates a point object from a given string. This string can represent coordinates in hex format, or points
+   * in multiple established formats.
+   * The function verifies the integrity of the provided data and throws errors if inconsistencies are found.
+   *
+   * @method fromString
+   * @static
+   *
+   * @param str The point representation string.
+   * @returns Returns a new point representing the given string.
+   * @throws `Error` If the point string value has a wrong length.
+   * @throws `Error` If the point format is unknown.
+   *
+   * @example
+   * const pointStr = 'abcdef';
+   * const point = Point.fromString(pointStr);
+   */
+  static fromString (str: string): Point {
+    const bytes = toArray(str, 'hex')
+    return Point.fromDER(bytes)
   }
 
   /**

--- a/src/primitives/PublicKey.ts
+++ b/src/primitives/PublicKey.ts
@@ -52,6 +52,21 @@ export default class PublicKey extends Point {
   }
 
   /**
+   * Static factory method to create a PublicKey instance from a number array.
+   *
+   * @param bytes - A number array representing a public key.
+   *
+   * @returns Returns the PublicKey created from the number array.
+   *
+   * @example
+   * const myPubKey = PublicKey.fromString("03....")
+   */
+  static fromDER (bytes: number[]): PublicKey {
+    const p = Point.fromDER(bytes)
+    return new PublicKey(p.x, p.y)
+  }
+
+  /**
    * @constructor
    * @param x - A point or the x-coordinate of the point. May be a number, a BigNumber, a string (which will be interpreted as hex), a number array, or null. If null, an "Infinity" point is constructed.
    * @param y - If x is not a point, the y-coordinate of the point, similar to x.
@@ -121,8 +136,8 @@ export default class PublicKey extends Point {
    * @example
    * const derPublicKey = myPubKey.toDER()
    */
-  toDER (): string {
-    return this.encode(true, 'hex') as string
+  toDER (enc?: 'hex' | undefined): string {
+    return this.encode(true, enc) as string
   }
 
   /**

--- a/src/primitives/__tests/PublicKey.test.ts
+++ b/src/primitives/__tests/PublicKey.test.ts
@@ -47,9 +47,22 @@ describe('PublicKey', () => {
     })
 
     test('toDER should return DER encoded string of public key', () => {
-      const derString = publicKey.toDER()
+      const derString = publicKey.toString()
       expect(typeof derString).toBe('string')
       expect(derString.length).toBe(66)
+    })
+
+    test('toDER should return DER encoded number[] of public key', () => {
+      const der = publicKey.toDER()
+      expect(typeof der).toBe('object')
+      expect(der.length).toBe(33)
+    })
+
+    test('fromDER and fromString should result in the same public key', () => {
+      const key = PrivateKey.fromRandom()
+      const original = key.toPublicKey()
+      const backAndForth = PublicKey.fromString(PublicKey.fromDER(original.toDER()).toString())
+      expect(backAndForth.toString()).toEqual(original.toString())
     })
   })
   describe('BRC42 vectors', () => {


### PR DESCRIPTION
## Description of Changes
Changes type of response from toDER. Could have far reaching consequences. Please review.

If your code previously did this:
```js
const pubkey = key.toPublicKey().toDER()
```
Then you need to update to:

```js
const pubkey = key.toPublicKey().toString()
// OR
const pubkey = key.toPublicKey().toDER('hex')
```

You no longer have to do this to get the number array -- as it wastes clock cycles doing this conversion back and forth.
```js
Utils.toArray(key.toPublicKey().toDER(), 'hex')
```

## Linked Issues / Tickets
Closes [Issue 110](https://github.com/bitcoin-sv/ts-sdk/issues/110)

## Testing Procedure

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged