### PR TITLE
1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
Try try again...

The process seems a bit broken if you are trying to guess the version number when updating CHANGE.LOG
and yet depending on merge order the version number may get used before your own merge.

This again is a branch with just an `npm version patch`.