### PR TITLE
ARCO-142: add competing txs to broadcast response

### DIFF
--- a/src/transaction/Broadcaster.ts
+++ b/src/transaction/Broadcaster.ts
@@ -12,6 +12,7 @@ export interface BroadcastResponse {
   status: 'success'
   txid: string
   message: string
+  competingTxs?: string[]
 }
 
 /**

--- a/src/transaction/broadcasters/ARC.ts
+++ b/src/transaction/broadcasters/ARC.ts
@@ -98,12 +98,16 @@ export default class ARC implements Broadcaster {
     try {
       const response = await this.httpClient.request<ArcResponse>(`${this.URL}/v1/tx`, requestOptions)
       if (response.ok) {
-        const { txid, extraInfo, txStatus } = response.data
-        return {
+        const { txid, extraInfo, txStatus, competingTxs } = response.data
+        let broadcastRes : BroadcastResponse = {
           status: 'success',
           txid,
           message: `${txStatus} ${extraInfo}`
         }
+        if (competingTxs) {
+          broadcastRes.competingTxs = competingTxs
+        }
+        return broadcastRes
       } else {
         const st = typeof response.status
         const r: BroadcastFailure = {
@@ -171,4 +175,5 @@ interface ArcResponse {
   txid: string
   extraInfo: string
   txStatus: string
+  competingTxs?: string[]
 }


### PR DESCRIPTION
## Description of Changes

Added `competingTxs` to `BroadcastResponse`, they are sent if double spend was attempted.

## Linked Issues / Tickets

#ARCO-142

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged