### PR TITLE
allow omitting fromPrivateKey for ephemeral key in electrumEncrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 
 ### Changed
+- electrumEncrypt correctly allows fromPrivateKey to be omitted
 
 ### Deprecated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.21",
+      "version": "1.1.22",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/compat/ECIES.ts
+++ b/src/compat/ECIES.ts
@@ -442,7 +442,7 @@ export default class ECIES {
      */
   public static electrumEncrypt (messageBuf: number[], toPublicKey: PublicKey, fromPrivateKey?: PrivateKey, noKey = false): number[] {
     let Rbuf
-    if (fromPrivateKey === null) {
+    if (!fromPrivateKey) {
       fromPrivateKey = PrivateKey.fromRandom()
     }
     if (!noKey) {

--- a/src/compat/ECIES.ts
+++ b/src/compat/ECIES.ts
@@ -469,7 +469,7 @@ export default class ECIES {
      * @param {PublicKey} [fromPublicKey=null] - The public key of the sender. If not provided, it is extracted from the message.
      * @returns {number[]} The decrypted message as a number array.
      */
-  public static electrumDecrypt (encBuf: number[], toPrivateKey: PrivateKey, fromPublicKey: PublicKey = null): number[] {
+  public static electrumDecrypt (encBuf: number[], toPrivateKey: PrivateKey, fromPublicKey?: PublicKey): number[] {
     const tagLength = 32
 
     const magic = encBuf.slice(0, 4)
@@ -477,7 +477,7 @@ export default class ECIES {
       throw new Error('Invalid Magic')
     }
     let offset = 4
-    if (fromPublicKey === null) {
+    if (!fromPublicKey) {
       // BIE1 use compressed public key, length is always 33.
       const pub = encBuf.slice(4, 37)
       fromPublicKey = PublicKey.fromString(toHex(pub))

--- a/src/compat/__tests/ECIES.test.ts
+++ b/src/compat/__tests/ECIES.test.ts
@@ -86,5 +86,12 @@ describe('#ECIES', () => {
       expect(ECIES.electrumDecrypt(ecdhMessageEncryptedBob, alicePrivateKey, bobPrivateKey.toPublicKey()))
         .toEqual(toArray('this is my ECDH test message', 'utf8'))
     })
+
+    it('should encrypt and decrypt using ephemeral fromPrivateKey', () => {
+      const message = toArray('this is my ephemeral key test message', 'utf8')
+      const encryptedMessage = ECIES.electrumEncrypt(message, bobPrivateKey.toPublicKey())
+      expect(ECIES.electrumDecrypt(encryptedMessage, bobPrivateKey))
+        .toEqual(message)
+    })
   })
 })


### PR DESCRIPTION
## Description of Changes

Remove the explicit null check to allow undefined fromPrivateKey in electrumEncrypt, and use the same style to omit fromPublicKey in electrumDecrypt. Aligns with existing style in bitcoreEncrypt as well.

## Testing Procedure

Does not impact tests.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Documentation is already correct
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
  - Doing this makes some change not related to this pr so I didn't commit the results, and there are existing unrelated lint errors
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged