### PR TITLE
Optimize SPV verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.1.24] - 2024-10-04
+### Fixed
+- Addressed #125
+- Optimized SPV verification
+
 ## [1.1.22] - 2024-09-02
 ### Added
 - Base64 mode support for BSM

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -5348,6 +5348,7 @@ export default class Point extends BasePoint {
     inf: boolean;
     static fromDER(bytes: number[]): Point 
     static fromString(str: string): Point 
+    static redSqrtOptimized(y2: BigNumber): BigNumber 
     static fromX(x: BigNumber | number | number[] | string, odd: boolean): Point 
     static fromJSON(obj: string | any[], isRed: boolean): Point 
     constructor(x: BigNumber | number | number[] | string | null, y: BigNumber | number | number[] | string | null, isRed: boolean = true) 
@@ -7903,7 +7904,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 sign = (msg: BigNumber, key: BigNumber, forceLowS: boolean = false, customK?: BigNumber | Function): Signature => {
     const curve = new Curve();
-    msg = truncateToN(msg);
+    msg = truncateToN(msg, undefined, curve);
     const bytes = curve.n.byteLength();
     const bkey = key.toArray("be", bytes);
     const nonce = msg.toArray("be", bytes);
@@ -7915,7 +7916,7 @@ sign = (msg: BigNumber, key: BigNumber, forceLowS: boolean = false, customK?: Bi
             : BigNumber.isBN(customK)
                 ? customK
                 : new BigNumber(drbg.generate(bytes), 16);
-        k = truncateToN(k, true);
+        k = truncateToN(k, true, curve);
         if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0) {
             if (BigNumber.isBN(customK)) {
                 throw new Error("Invalid fixed custom K value (must be more than 1 and less than N-1)");
@@ -7969,7 +7970,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 verify = (msg: BigNumber, sig: Signature, key: Point): boolean => {
     const curve = new Curve();
-    msg = truncateToN(msg);
+    msg = truncateToN(msg, undefined, curve);
     const r = sig.r;
     const s = sig.s;
     if (r.cmpn(1) < 0 || r.cmp(curve.n) >= 0) {

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -52,7 +52,7 @@ export default interface TransactionInput {
         sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>;
         estimateLength: (tx: Transaction, inputIndex: number) => Promise<number>;
     };
-    sequence: number;
+    sequence?: number;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.23",
+      "version": "1.1.24",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/Curve.ts
+++ b/src/primitives/Curve.ts
@@ -33,7 +33,7 @@ export default class Curve {
   _bitLength: number
 
   // Represent num in a w-NAF form
-  static assert (
+  static assert(
     expression: unknown,
     message: string = 'Elliptic curve assertion failed'
   ): void {
@@ -42,7 +42,7 @@ export default class Curve {
     }
   }
 
-  getNAF (num: BigNumber, w: number, bits: number): number[] {
+  getNAF(num: BigNumber, w: number, bits: number): number[] {
     const naf = new Array(Math.max(num.bitLength(), bits) + 1)
     naf.fill(0)
 
@@ -67,7 +67,7 @@ export default class Curve {
   }
 
   // Represent k1, k2 in a Joint Sparse Form
-  getJSF (k1: BigNumber, k2: BigNumber): number[][] {
+  getJSF(k1: BigNumber, k2: BigNumber): number[][] {
     const jsf: any[][] = [
       [],
       []
@@ -115,9 +115,9 @@ export default class Curve {
     return jsf
   }
 
-  static cachedProperty (obj, name: string, computer): void {
+  static cachedProperty(obj, name: string, computer): void {
     const key = '_' + name
-    obj.prototype[name] = function cachedProperty () {
+    obj.prototype[name] = function cachedProperty() {
       const r = this[key] !== undefined
         ? this[key]
         : this[key] = computer.call(this)
@@ -125,17 +125,24 @@ export default class Curve {
     }
   }
 
-  static parseBytes (bytes: string | number[]): number[] {
+  static parseBytes(bytes: string | number[]): number[] {
     return typeof bytes === 'string'
       ? toArray(bytes, 'hex')
       : bytes
   }
 
-  static intFromLE (bytes: number[]): BigNumber {
+  static intFromLE(bytes: number[]): BigNumber {
     return new BigNumber(bytes, 'hex', 'le')
   }
 
-  constructor () {
+  constructor() {
+    if (typeof globalCurve !== 'undefined') {
+      return globalCurve
+    } else {
+      /* eslint-disable @typescript-eslint/no-this-alias */
+      globalCurve = this
+    }
+
     const precomputed = {
       doubles: {
         step: 4,
@@ -916,13 +923,6 @@ export default class Curve {
         ]
       }
     }
-
-    if (typeof globalCurve !== 'undefined') {
-      return globalCurve
-    } else {
-      /* eslint-disable @typescript-eslint/no-this-alias */
-      globalCurve = this
-    }
     const conf = {
       prime: 'k256',
       p: 'ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff fffffffe fffffc2f',
@@ -988,7 +988,7 @@ export default class Curve {
     this._endoWnafT2 = new Array(4)
   }
 
-  _getEndomorphism (conf): {
+  _getEndomorphism(conf): {
     beta: BigNumber
     lambda: BigNumber
     basis: Array<{ a: BigNumber, b: BigNumber }>
@@ -1040,7 +1040,7 @@ export default class Curve {
     }
   };
 
-  _getEndoRoots (num: BigNumber): [BigNumber, BigNumber] {
+  _getEndoRoots(num: BigNumber): [BigNumber, BigNumber] {
     // Find roots of for x^2 + x + 1 in F
     // Root = (-1 +- Sqrt(-3)) / 2
     //
@@ -1055,7 +1055,7 @@ export default class Curve {
     return [l1, l2]
   };
 
-  _getEndoBasis (lambda: BigNumber): [{ a: BigNumber, b: BigNumber }, { a: BigNumber, b: BigNumber }] {
+  _getEndoBasis(lambda: BigNumber): [{ a: BigNumber, b: BigNumber }, { a: BigNumber, b: BigNumber }] {
     // aprxSqrt >= sqrt(this.n)
     const aprxSqrt = this.n.ushrn(Math.floor(this.n.bitLength() / 2))
 
@@ -1131,7 +1131,7 @@ export default class Curve {
     ]
   }
 
-  _endoSplit (k: BigNumber): { k1: BigNumber, k2: BigNumber } {
+  _endoSplit(k: BigNumber): { k1: BigNumber, k2: BigNumber } {
     const basis = this.endo.basis
     const v1 = basis[0]
     const v2 = basis[1]
@@ -1150,7 +1150,7 @@ export default class Curve {
     return { k1, k2 }
   }
 
-  validate (point: Point): boolean {
+  validate(point: Point): boolean {
     if (point.inf) { return true }
 
     const x = point.x

--- a/src/primitives/Curve.ts
+++ b/src/primitives/Curve.ts
@@ -33,7 +33,7 @@ export default class Curve {
   _bitLength: number
 
   // Represent num in a w-NAF form
-  static assert(
+  static assert (
     expression: unknown,
     message: string = 'Elliptic curve assertion failed'
   ): void {
@@ -42,7 +42,7 @@ export default class Curve {
     }
   }
 
-  getNAF(num: BigNumber, w: number, bits: number): number[] {
+  getNAF (num: BigNumber, w: number, bits: number): number[] {
     const naf = new Array(Math.max(num.bitLength(), bits) + 1)
     naf.fill(0)
 
@@ -67,7 +67,7 @@ export default class Curve {
   }
 
   // Represent k1, k2 in a Joint Sparse Form
-  getJSF(k1: BigNumber, k2: BigNumber): number[][] {
+  getJSF (k1: BigNumber, k2: BigNumber): number[][] {
     const jsf: any[][] = [
       [],
       []
@@ -115,9 +115,9 @@ export default class Curve {
     return jsf
   }
 
-  static cachedProperty(obj, name: string, computer): void {
+  static cachedProperty (obj, name: string, computer): void {
     const key = '_' + name
-    obj.prototype[name] = function cachedProperty() {
+    obj.prototype[name] = function cachedProperty () {
       const r = this[key] !== undefined
         ? this[key]
         : this[key] = computer.call(this)
@@ -125,17 +125,17 @@ export default class Curve {
     }
   }
 
-  static parseBytes(bytes: string | number[]): number[] {
+  static parseBytes (bytes: string | number[]): number[] {
     return typeof bytes === 'string'
       ? toArray(bytes, 'hex')
       : bytes
   }
 
-  static intFromLE(bytes: number[]): BigNumber {
+  static intFromLE (bytes: number[]): BigNumber {
     return new BigNumber(bytes, 'hex', 'le')
   }
 
-  constructor() {
+  constructor () {
     if (typeof globalCurve !== 'undefined') {
       return globalCurve
     } else {
@@ -988,7 +988,7 @@ export default class Curve {
     this._endoWnafT2 = new Array(4)
   }
 
-  _getEndomorphism(conf): {
+  _getEndomorphism (conf): {
     beta: BigNumber
     lambda: BigNumber
     basis: Array<{ a: BigNumber, b: BigNumber }>
@@ -1040,7 +1040,7 @@ export default class Curve {
     }
   };
 
-  _getEndoRoots(num: BigNumber): [BigNumber, BigNumber] {
+  _getEndoRoots (num: BigNumber): [BigNumber, BigNumber] {
     // Find roots of for x^2 + x + 1 in F
     // Root = (-1 +- Sqrt(-3)) / 2
     //
@@ -1055,7 +1055,7 @@ export default class Curve {
     return [l1, l2]
   };
 
-  _getEndoBasis(lambda: BigNumber): [{ a: BigNumber, b: BigNumber }, { a: BigNumber, b: BigNumber }] {
+  _getEndoBasis (lambda: BigNumber): [{ a: BigNumber, b: BigNumber }, { a: BigNumber, b: BigNumber }] {
     // aprxSqrt >= sqrt(this.n)
     const aprxSqrt = this.n.ushrn(Math.floor(this.n.bitLength() / 2))
 
@@ -1131,7 +1131,7 @@ export default class Curve {
     ]
   }
 
-  _endoSplit(k: BigNumber): { k1: BigNumber, k2: BigNumber } {
+  _endoSplit (k: BigNumber): { k1: BigNumber, k2: BigNumber } {
     const basis = this.endo.basis
     const v1 = basis[0]
     const v2 = basis[1]
@@ -1150,7 +1150,7 @@ export default class Curve {
     return { k1, k2 }
   }
 
-  validate(point: Point): boolean {
+  validate (point: Point): boolean {
     if (point.inf) { return true }
 
     const x = point.x

--- a/src/primitives/ECDSA.ts
+++ b/src/primitives/ECDSA.ts
@@ -23,10 +23,9 @@ import DRBG from './DRBG.js'
  * let msg = new BigNumber('1234567890abcdef', 16);
  * let truncatedMsg = truncateToN(msg);
  */
-function truncateToN (msg: BigNumber, truncOnly?: boolean): BigNumber {
-  const curve = new Curve()
+function truncateToN(msg: BigNumber, truncOnly?: boolean, curve = new Curve()): BigNumber {
   const delta = msg.byteLength() * 8 - curve.n.bitLength()
-  if (delta > 0) { msg = msg.ushrn(delta) }
+  if (delta > 0) { msg.iushrn(delta) }
   if (!truncOnly && msg.cmp(curve.n) >= 0) {
     return msg.sub(curve.n)
   } else {
@@ -51,7 +50,7 @@ function truncateToN (msg: BigNumber, truncOnly?: boolean): BigNumber {
  */
 export const sign = (msg: BigNumber, key: BigNumber, forceLowS: boolean = false, customK?: BigNumber | Function): Signature => {
   const curve = new Curve()
-  msg = truncateToN(msg)
+  msg = truncateToN(msg, undefined, curve)
 
   // Zero-extend key to provide enough entropy
   const bytes = curve.n.byteLength()
@@ -73,7 +72,7 @@ export const sign = (msg: BigNumber, key: BigNumber, forceLowS: boolean = false,
       : BigNumber.isBN(customK)
         ? customK
         : new BigNumber(drbg.generate(bytes), 16)
-    k = truncateToN(k, true)
+    k = truncateToN(k, true, curve)
     if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0) {
       if (BigNumber.isBN(customK)) {
         throw new Error('Invalid fixed custom K value (must be more than 1 and less than N-1)')
@@ -140,7 +139,7 @@ export const sign = (msg: BigNumber, key: BigNumber, forceLowS: boolean = false,
  */
 export const verify = (msg: BigNumber, sig: Signature, key: Point): boolean => {
   const curve = new Curve()
-  msg = truncateToN(msg)
+  msg = truncateToN(msg, undefined, curve)
   // Perform primitive values validation
   const r = sig.r
   const s = sig.s

--- a/src/primitives/ECDSA.ts
+++ b/src/primitives/ECDSA.ts
@@ -23,7 +23,7 @@ import DRBG from './DRBG.js'
  * let msg = new BigNumber('1234567890abcdef', 16);
  * let truncatedMsg = truncateToN(msg);
  */
-function truncateToN(msg: BigNumber, truncOnly?: boolean, curve = new Curve()): BigNumber {
+function truncateToN (msg: BigNumber, truncOnly?: boolean, curve = new Curve()): BigNumber {
   const delta = msg.byteLength() * 8 - curve.n.bitLength()
   if (delta > 0) { msg.iushrn(delta) }
   if (!truncOnly && msg.cmp(curve.n) >= 0) {

--- a/src/primitives/Point.ts
+++ b/src/primitives/Point.ts
@@ -17,10 +17,10 @@ import ReductionContext from './ReductionContext.js'
  * @property inf - Flag to record if the point is at infinity in the Elliptic Curve.
  */
 export default class Point extends BasePoint {
-  private static red: any = new ReductionContext('k256')
-  private static a: BigNumber = new BigNumber(0).toRed(Point.red)
-  private static b: BigNumber = new BigNumber(7).toRed(Point.red)
-  private static zero: BigNumber = new BigNumber(0).toRed(Point.red)
+  private static readonly red: any = new ReductionContext('k256')
+  private static readonly a: BigNumber = new BigNumber(0).toRed(Point.red)
+  private static readonly b: BigNumber = new BigNumber(7).toRed(Point.red)
+  private static readonly zero: BigNumber = new BigNumber(0).toRed(Point.red)
   x: BigNumber | null
   y: BigNumber | null
   inf: boolean
@@ -41,7 +41,7 @@ export default class Point extends BasePoint {
    * const derPoint = [ 2, 18, 123, 108, 125, 83, 1, 251, 164, 214, 16, 119, 200, 216, 210, 193, 251, 193, 129, 67, 97, 146, 210, 216, 77, 254, 18, 6, 150, 190, 99, 198, 128 ];
    * const point = Point.fromDER(derPoint);
    */
-  static fromDER(bytes: number[]): Point {
+  static fromDER (bytes: number[]): Point {
     const len = 32
     // uncompressed, hybrid-odd, hybrid-even
     if ((bytes[0] === 0x04 || bytes[0] === 0x06 || bytes[0] === 0x07) &&
@@ -86,16 +86,16 @@ export default class Point extends BasePoint {
    * const pointStr = 'abcdef';
    * const point = Point.fromString(pointStr);
    */
-  static fromString(str: string): Point {
+  static fromString (str: string): Point {
     const bytes = toArray(str, 'hex')
     return Point.fromDER(bytes)
   }
 
-  static redSqrtOptimized(y2: BigNumber): BigNumber {
-    const red = Point.red;
-    const p = red.m; // The modulus
-    const exponent = p.addn(1).iushrn(2); // (p + 1) / 4
-    return y2.redPow(exponent);
+  static redSqrtOptimized (y2: BigNumber): BigNumber {
+    const red = Point.red
+    const p = red.m // The modulus
+    const exponent = p.addn(1).iushrn(2) // (p + 1) / 4
+    return y2.redPow(exponent)
   }
 
   /**
@@ -113,7 +113,7 @@ export default class Point extends BasePoint {
    * const xCoordinate = new BigNumber('10');
    * const point = Point.fromX(xCoordinate, true);
    */
-  static fromX(x: BigNumber | number | number[] | string, odd: boolean): Point {
+  static fromX (x: BigNumber | number | number[] | string, odd: boolean): Point {
     const red = Point.red
     const a = Point.a
     const b = Point.b
@@ -121,12 +121,12 @@ export default class Point extends BasePoint {
 
     // Convert x to BigNumber and reduce it
     if (typeof x === 'string' || Array.isArray(x)) {
-      x = new BigNumber(x as string | number[], 16);
+      x = new BigNumber(x, 16)
     } else if (typeof x === 'number') {
-      x = new BigNumber(x);
+      x = new BigNumber(x)
     }
 
-    x = (x as BigNumber).toRed(red);
+    x = (x).toRed(red)
 
     // Compute y^2 = x^3 + ax + b
     const y2 = x.redSqr().redIMul(x).redIAdd(b)
@@ -161,7 +161,7 @@ export default class Point extends BasePoint {
    * const serializedPoint = '{"x":52,"y":15}';
    * const point = Point.fromJSON(serializedPoint, true);
    */
-  static fromJSON(
+  static fromJSON (
     obj: string | any[], isRed: boolean
   ): Point {
     if (typeof obj === 'string') {
@@ -181,15 +181,15 @@ export default class Point extends BasePoint {
       beta: null,
       doubles: typeof pre.doubles === 'object' && pre.doubles !== null
         ? {
-          step: pre.doubles.step,
-          points: [res].concat(pre.doubles.points.map(obj2point))
-        }
+            step: pre.doubles.step,
+            points: [res].concat(pre.doubles.points.map(obj2point))
+          }
         : undefined,
       naf: typeof pre.naf === 'object' && pre.naf !== null
         ? {
-          wnd: pre.naf.wnd,
-          points: [res].concat(pre.naf.points.map(obj2point))
-        }
+            wnd: pre.naf.wnd,
+            points: [res].concat(pre.naf.points.map(obj2point))
+          }
         : undefined
     }
     return res
@@ -205,7 +205,7 @@ export default class Point extends BasePoint {
    * new Point('abc123', 'def456');
    * new Point(null, null); // Generates Infinity point.
    */
-  constructor(
+  constructor (
     x: BigNumber | number | number[] | string | null,
     y: BigNumber | number | number[] | string | null,
     isRed: boolean = true
@@ -247,7 +247,7 @@ export default class Point extends BasePoint {
    * const aPoint = new Point(x, y);
    * const isValid = aPoint.validate();
    */
-  validate(): boolean {
+  validate (): boolean {
     return this.curve.validate(this)
   }
 
@@ -266,7 +266,7 @@ export default class Point extends BasePoint {
    * const encodedPointArray = aPoint.encode();
    * const encodedPointHex = aPoint.encode(true, 'hex');
    */
-  encode(compact: boolean = true, enc?: 'hex'): number[] | string {
+  encode (compact: boolean = true, enc?: 'hex'): number[] | string {
     const len = this.curve.p.byteLength()
     const x = this.getX().toArray('be', len)
     let res: number[]
@@ -293,7 +293,7 @@ export default class Point extends BasePoint {
    * const aPoint = new Point(x, y);
    * const stringPoint = aPoint.toString();
    */
-  toString(): string {
+  toString (): string {
     return this.encode(true, 'hex') as string
   }
 
@@ -307,24 +307,24 @@ export default class Point extends BasePoint {
    * const aPoint = new Point(x, y);
    * const jsonPoint = aPoint.toJSON();
    */
-  toJSON(): [BigNumber | null, BigNumber | null, { doubles: { step: any, points: any[] } | undefined, naf: { wnd: any, points: any[] } | undefined }?] {
+  toJSON (): [BigNumber | null, BigNumber | null, { doubles: { step: any, points: any[] } | undefined, naf: { wnd: any, points: any[] } | undefined }?] {
     if (this.precomputed == null) { return [this.x, this.y] }
 
     return [this.x, this.y, typeof this.precomputed === 'object' && this.precomputed !== null
       ? {
-        doubles: (this.precomputed.doubles != null)
-          ? {
-            step: this.precomputed.doubles.step,
-            points: this.precomputed.doubles.points.slice(1)
-          }
-          : undefined,
-        naf: (this.precomputed.naf != null)
-          ? {
-            wnd: this.precomputed.naf.wnd,
-            points: this.precomputed.naf.points.slice(1)
-          }
-          : undefined
-      }
+          doubles: (this.precomputed.doubles != null)
+            ? {
+                step: this.precomputed.doubles.step,
+                points: this.precomputed.doubles.points.slice(1)
+              }
+            : undefined,
+          naf: (this.precomputed.naf != null)
+            ? {
+                wnd: this.precomputed.naf.wnd,
+                points: this.precomputed.naf.points.slice(1)
+              }
+            : undefined
+        }
       : undefined]
   }
 
@@ -338,7 +338,7 @@ export default class Point extends BasePoint {
    * const aPoint = new Point(x, y);
    * console.log(aPoint.inspect());
    */
-  inspect(): string {
+  inspect (): string {
     if (this.isInfinity()) {
       return '<EC Point Infinity>'
     }
@@ -355,7 +355,7 @@ export default class Point extends BasePoint {
    * const p = new Point(null, null);
    * console.log(p.isInfinity()); // outputs: true
    */
-  isInfinity(): boolean {
+  isInfinity (): boolean {
     return this.inf
   }
 
@@ -371,7 +371,7 @@ export default class Point extends BasePoint {
    * const p2 = new Point(2, 3);
    * const result = p1.add(p2);
    */
-  add(p: Point): Point {
+  add (p: Point): Point {
     // O + P = P
     if (this.inf) { return p }
 
@@ -403,7 +403,7 @@ export default class Point extends BasePoint {
    * const P = new Point('123', '456');
    * const result = P.dbl();
    * */
-  dbl(): Point {
+  dbl (): Point {
     if (this.inf) { return this }
 
     // 2P = O
@@ -430,7 +430,7 @@ export default class Point extends BasePoint {
    * const P = new Point('123', '456');
    * const x = P.getX();
    */
-  getX(): BigNumber {
+  getX (): BigNumber {
     return this.x.fromRed()
   }
 
@@ -441,7 +441,7 @@ export default class Point extends BasePoint {
    * const P = new Point('123', '456');
    * const x = P.getX();
    */
-  getY(): BigNumber {
+  getY (): BigNumber {
     return this.y.fromRed()
   }
 
@@ -456,7 +456,7 @@ export default class Point extends BasePoint {
    * const p = new Point(1, 2);
    * const result = p.mul(2); // this doubles the Point
    */
-  mul(k: BigNumber | number | number[] | string): Point {
+  mul (k: BigNumber | number | number[] | string): Point {
     if (!BigNumber.isBN(k)) {
       k = new BigNumber(k as number, 16)
     }
@@ -485,7 +485,7 @@ export default class Point extends BasePoint {
    * const p2 = new Point(2, 3);
    * const result = p1.mulAdd(2, p2, 3);
    */
-  mulAdd(k1: BigNumber, p2: Point, k2: BigNumber): Point {
+  mulAdd (k1: BigNumber, p2: Point, k2: BigNumber): Point {
     const points = [this, p2]
     const coeffs = [k1, k2]
     return this._endoWnafMulAdd(points, coeffs) as Point
@@ -506,7 +506,7 @@ export default class Point extends BasePoint {
    * const p2 = new Point(2, 3);
    * const result = p1.jmulAdd(2, p2, 3);
    */
-  jmulAdd(k1: BigNumber, p2: Point, k2: BigNumber): JPoint {
+  jmulAdd (k1: BigNumber, p2: Point, k2: BigNumber): JPoint {
     const points = [this, p2]
     const coeffs = [k1, k2]
     return this._endoWnafMulAdd(points, coeffs, true) as JPoint
@@ -525,7 +525,7 @@ export default class Point extends BasePoint {
    * const p2 = new Point(5, 20);
    * const areEqual = p1.eq(p2); // returns true
    */
-  eq(p: Point): boolean {
+  eq (p: Point): boolean {
     return this === p || (
       (this.inf === p.inf) &&
       (this.inf || (this.x.cmp(p.x) === 0 && this.y.cmp(p.y) === 0)))
@@ -540,7 +540,7 @@ export default class Point extends BasePoint {
    * const P = new Point('123', '456');
    * const result = P.neg();
    */
-  neg(_precompute?: boolean): Point {
+  neg (_precompute?: boolean): Point {
     if (this.inf) { return this }
 
     const res = new Point(this.x, this.y.redNeg())
@@ -576,7 +576,7 @@ export default class Point extends BasePoint {
    * const p = new Point(5, 20);
    * const doubledPoint = p.dblp(10); // returns the point after "doubled" 10 times
    */
-  dblp(k: number): Point {
+  dblp (k: number): Point {
     /* eslint-disable @typescript-eslint/no-this-alias */
     let r: Point = this
     for (let i = 0; i < k; i++) { r = r.dbl() }
@@ -594,7 +594,7 @@ export default class Point extends BasePoint {
    * const point = new Point(xCoordinate, yCoordinate);
    * const jacobianPoint = point.toJ();
    */
-  toJ(): JPoint {
+  toJ (): JPoint {
     if (this.inf) {
       return new JPoint(null, null, null)
     }
@@ -602,7 +602,7 @@ export default class Point extends BasePoint {
     return res
   }
 
-  private _getBeta(): undefined | Point {
+  private _getBeta (): undefined | Point {
     if (typeof this.curve.endo !== 'object') { return }
 
     const pre = this.precomputed
@@ -621,22 +621,22 @@ export default class Point extends BasePoint {
         beta: null,
         naf: (pre.naf != null)
           ? {
-            wnd: pre.naf.wnd,
-            points: pre.naf.points.map(endoMul)
-          }
+              wnd: pre.naf.wnd,
+              points: pre.naf.points.map(endoMul)
+            }
           : undefined,
         doubles: (pre.doubles != null)
           ? {
-            step: pre.doubles.step,
-            points: pre.doubles.points.map(endoMul)
-          }
+              step: pre.doubles.step,
+              points: pre.doubles.points.map(endoMul)
+            }
           : undefined
       }
     }
     return beta
   }
 
-  private _fixedNafMul(k: BigNumber): Point {
+  private _fixedNafMul (k: BigNumber): Point {
     if (typeof this.precomputed !== 'object' || this.precomputed === null) {
       throw new Error('_fixedNafMul requires precomputed values for the point')
     }
@@ -672,7 +672,7 @@ export default class Point extends BasePoint {
     return a.toP()
   }
 
-  private _wnafMulAdd(
+  private _wnafMulAdd (
     defW: number,
     points: Point[],
     coeffs: BigNumber[],
@@ -751,7 +751,6 @@ export default class Point extends BasePoint {
       }
     }
 
-
     let acc = new JPoint(null, null, null)
     const tmp = this.curve._wnafT4
     for (let i = max; i >= 0; i--) {
@@ -799,7 +798,7 @@ export default class Point extends BasePoint {
     }
   }
 
-  private _endoWnafMulAdd(points: Point[], coeffs, jacobianResult?: boolean): BasePoint {
+  private _endoWnafMulAdd (points: Point[], coeffs, jacobianResult?: boolean): BasePoint {
     const npoints = this.curve._endoWnafT1
     const ncoeffs = this.curve._endoWnafT2
     let i
@@ -832,7 +831,7 @@ export default class Point extends BasePoint {
     return res
   }
 
-  private _hasDoubles(k: BigNumber): boolean {
+  private _hasDoubles (k: BigNumber): boolean {
     if (this.precomputed == null) { return false }
 
     const doubles = this.precomputed.doubles
@@ -841,7 +840,7 @@ export default class Point extends BasePoint {
     return doubles.points.length >= Math.ceil((k.bitLength() + 1) / doubles.step)
   };
 
-  private _getDoubles(
+  private _getDoubles (
     step?: number,
     power?: number
   ): { step: number, points: any[] } {
@@ -866,7 +865,7 @@ export default class Point extends BasePoint {
     }
   };
 
-  private _getNAFPoints(wnd: number): { wnd: number, points: any[] } {
+  private _getNAFPoints (wnd: number): { wnd: number, points: any[] } {
     if (
       typeof this.precomputed === 'object' && this.precomputed !== null &&
       typeof this.precomputed.naf === 'object' && this.precomputed.naf !== null

--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -167,7 +167,7 @@ export const encode = (arr: number[], enc?: 'hex' | 'utf8'): string | number[] =
  * const bytes = [72, 101, 108, 108, 111]; // Represents the string "Hello"
  * console.log(toBase64(bytes)); // Outputs: SGVsbG8=
  */
-export function toBase64(byteArray: number[]): string {
+export function toBase64 (byteArray: number[]): string {
   const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let result = ''
   let i: number
@@ -307,11 +307,11 @@ export const fromBase58Check = (str: string, enc?: 'hex', prefixLength: number =
 export class Writer {
   public bufs: number[][]
 
-  constructor(bufs?: number[][]) {
+  constructor (bufs?: number[][]) {
     this.bufs = bufs || []
   }
 
-  getLength(): number {
+  getLength (): number {
     let len = 0
     for (const buf of this.bufs) {
       len = len + buf.length
@@ -319,7 +319,7 @@ export class Writer {
     return len
   }
 
-  toArray(): number[] {
+  toArray (): number[] {
     const totalLength = this.getLength()
     const ret = new Array(totalLength)
     let offset = 0
@@ -331,12 +331,12 @@ export class Writer {
     return ret
   }
 
-  write(buf: number[]): Writer {
+  write (buf: number[]): Writer {
     this.bufs.push(buf)
     return this
   }
 
-  writeReverse(buf: number[]): Writer {
+  writeReverse (buf: number[]): Writer {
     const buf2: number[] = new Array(buf.length)
     for (let i = 0; i < buf2.length; i++) {
       buf2[i] = buf[buf.length - 1 - i]
@@ -345,21 +345,21 @@ export class Writer {
     return this
   }
 
-  writeUInt8(n: number): Writer {
+  writeUInt8 (n: number): Writer {
     const buf = new Array(1)
     buf[0] = n
     this.write(buf)
     return this
   }
 
-  writeInt8(n: number): Writer {
+  writeInt8 (n: number): Writer {
     const buf = new Array(1)
     buf[0] = n & 0xFF
     this.write(buf)
     return this
   }
 
-  writeUInt16BE(n: number): Writer {
+  writeUInt16BE (n: number): Writer {
     this.bufs.push([
       (n >> 8) & 0xFF, // shift right 8 bits to get the high byte
       n & 0xFF // low byte is just the last 8 bits
@@ -367,11 +367,11 @@ export class Writer {
     return this
   }
 
-  writeInt16BE(n: number): Writer {
+  writeInt16BE (n: number): Writer {
     return this.writeUInt16BE(n & 0xFFFF) // Mask with 0xFFFF to get the lower 16 bits
   }
 
-  writeUInt16LE(n: number): Writer {
+  writeUInt16LE (n: number): Writer {
     this.bufs.push([
       n & 0xFF, // low byte is just the last 8 bits
       (n >> 8) & 0xFF // shift right 8 bits to get the high byte
@@ -379,11 +379,11 @@ export class Writer {
     return this
   }
 
-  writeInt16LE(n: number): Writer {
+  writeInt16LE (n: number): Writer {
     return this.writeUInt16LE(n & 0xFFFF) // Mask with 0xFFFF to get the lower 16 bits
   }
 
-  writeUInt32BE(n: number): Writer {
+  writeUInt32BE (n: number): Writer {
     this.bufs.push([
       (n >> 24) & 0xFF, // highest byte
       (n >> 16) & 0xFF,
@@ -393,11 +393,11 @@ export class Writer {
     return this
   }
 
-  writeInt32BE(n: number): Writer {
+  writeInt32BE (n: number): Writer {
     return this.writeUInt32BE(n >>> 0) // Using unsigned right shift to handle negative numbers
   }
 
-  writeUInt32LE(n: number): Writer {
+  writeUInt32LE (n: number): Writer {
     this.bufs.push([
       n & 0xFF, // lowest byte
       (n >> 8) & 0xFF,
@@ -407,41 +407,41 @@ export class Writer {
     return this
   }
 
-  writeInt32LE(n: number): Writer {
+  writeInt32LE (n: number): Writer {
     return this.writeUInt32LE(n >>> 0) // Using unsigned right shift to handle negative numbers
   }
 
-  writeUInt64BEBn(bn: BigNumber): Writer {
+  writeUInt64BEBn (bn: BigNumber): Writer {
     const buf = bn.toArray('be', 8)
     this.write(buf)
     return this
   }
 
-  writeUInt64LEBn(bn: BigNumber): Writer {
+  writeUInt64LEBn (bn: BigNumber): Writer {
     const buf = bn.toArray('be', 8)
     this.writeReverse(buf)
     return this
   }
 
-  writeUInt64LE(n: number): Writer {
+  writeUInt64LE (n: number): Writer {
     const buf = new BigNumber(n).toArray('be', 8)
     this.writeReverse(buf)
     return this
   }
 
-  writeVarIntNum(n: number): Writer {
+  writeVarIntNum (n: number): Writer {
     const buf = Writer.varIntNum(n)
     this.write(buf)
     return this
   }
 
-  writeVarIntBn(bn: BigNumber): Writer {
+  writeVarIntBn (bn: BigNumber): Writer {
     const buf = Writer.varIntBn(bn)
     this.write(buf)
     return this
   }
 
-  static varIntNum(n: number): number[] {
+  static varIntNum (n: number): number[] {
     let buf: number[]
     if (n < 253) {
       buf = [n] // 1 byte
@@ -481,7 +481,7 @@ export class Writer {
     return buf
   }
 
-  static varIntBn(bn: BigNumber): number[] {
+  static varIntBn (bn: BigNumber): number[] {
     let buf: number[]
     if (bn.ltn(253)) {
       const n = bn.toNumber()
@@ -509,23 +509,23 @@ export class Reader {
   public bin: number[]
   public pos: number
 
-  constructor(bin: number[] = [], pos: number = 0) {
+  constructor (bin: number[] = [], pos: number = 0) {
     this.bin = bin
     this.pos = pos
   }
 
-  public eof(): boolean {
+  public eof (): boolean {
     return this.pos >= this.bin.length
   }
 
-  public read(len = this.bin.length): number[] {
+  public read (len = this.bin.length): number[] {
     const start = this.pos
     const end = this.pos + len
     this.pos = end
     return this.bin.slice(start, end)
   }
 
-  public readReverse(len = this.bin.length): number[] {
+  public readReverse (len = this.bin.length): number[] {
     const buf2 = new Array(len)
     for (let i = 0; i < len; i++) {
       buf2[i] = this.bin[this.pos + len - 1 - i]
@@ -534,45 +534,45 @@ export class Reader {
     return buf2
   }
 
-  public readUInt8(): number {
+  public readUInt8 (): number {
     const val = this.bin[this.pos]
     this.pos += 1
     return val
   }
 
-  public readInt8(): number {
+  public readInt8 (): number {
     const val = this.bin[this.pos]
     this.pos += 1
     // If the sign bit is set, convert to negative value
     return (val & 0x80) !== 0 ? val - 0x100 : val
   }
 
-  public readUInt16BE(): number {
+  public readUInt16BE (): number {
     const val = (this.bin[this.pos] << 8) | this.bin[this.pos + 1]
     this.pos += 2
     return val
   }
 
-  public readInt16BE(): number {
+  public readInt16BE (): number {
     const val = this.readUInt16BE()
     // If the sign bit is set, convert to negative value
     return (val & 0x8000) !== 0 ? val - 0x10000 : val
   }
 
-  public readUInt16LE(): number {
+  public readUInt16LE (): number {
     const val = this.bin[this.pos] | (this.bin[this.pos + 1] << 8)
     this.pos += 2
     return val
   }
 
-  public readInt16LE(): number {
+  public readInt16LE (): number {
     const val = this.readUInt16LE()
     // If the sign bit is set, convert to negative value
     const x = (val & 0x8000) !== 0 ? val - 0x10000 : val
     return x
   }
 
-  public readUInt32BE(): number {
+  public readUInt32BE (): number {
     const val =
       (this.bin[this.pos] * 0x1000000) + // Shift the first byte by 24 bits
       ((this.bin[this.pos + 1] << 16) | // Shift the second byte by 16 bits
@@ -582,13 +582,13 @@ export class Reader {
     return val
   }
 
-  public readInt32BE(): number {
+  public readInt32BE (): number {
     const val = this.readUInt32BE()
     // If the sign bit is set, convert to negative value
     return (val & 0x80000000) !== 0 ? val - 0x100000000 : val
   }
 
-  public readUInt32LE(): number {
+  public readUInt32LE (): number {
     const val =
       (this.bin[this.pos] |
         (this.bin[this.pos + 1] << 8) |
@@ -598,26 +598,26 @@ export class Reader {
     return val
   }
 
-  public readInt32LE(): number {
+  public readInt32LE (): number {
     const val = this.readUInt32LE()
     // Explicitly check if the sign bit is set and then convert to a negative value
     return (val & 0x80000000) !== 0 ? val - 0x100000000 : val
   }
 
-  public readUInt64BEBn(): BigNumber {
+  public readUInt64BEBn (): BigNumber {
     const bin = this.bin.slice(this.pos, this.pos + 8)
     const bn = new BigNumber(bin)
     this.pos = this.pos + 8
     return bn
   }
 
-  public readUInt64LEBn(): BigNumber {
+  public readUInt64LEBn (): BigNumber {
     const bin = this.readReverse(8)
     const bn = new BigNumber(bin)
     return bn
   }
 
-  public readVarIntNum(): number {
+  public readVarIntNum (): number {
     const first = this.readUInt8()
     let bn: BigNumber
     let n: number
@@ -638,7 +638,7 @@ export class Reader {
     }
   }
 
-  public readVarInt(): number[] {
+  public readVarInt (): number[] {
     const first = this.bin[this.pos]
     switch (first) {
       case 0xfd:
@@ -652,7 +652,7 @@ export class Reader {
     }
   }
 
-  public readVarIntBn(): BigNumber {
+  public readVarIntBn (): BigNumber {
     const first = this.readUInt8()
     switch (first) {
       case 0xfd:

--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -167,7 +167,7 @@ export const encode = (arr: number[], enc?: 'hex' | 'utf8'): string | number[] =
  * const bytes = [72, 101, 108, 108, 111]; // Represents the string "Hello"
  * console.log(toBase64(bytes)); // Outputs: SGVsbG8=
  */
-export function toBase64 (byteArray: number[]): string {
+export function toBase64(byteArray: number[]): string {
   const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let result = ''
   let i: number
@@ -307,11 +307,11 @@ export const fromBase58Check = (str: string, enc?: 'hex', prefixLength: number =
 export class Writer {
   public bufs: number[][]
 
-  constructor (bufs?: number[][]) {
+  constructor(bufs?: number[][]) {
     this.bufs = bufs || []
   }
 
-  getLength (): number {
+  getLength(): number {
     let len = 0
     for (const buf of this.bufs) {
       len = len + buf.length
@@ -319,20 +319,24 @@ export class Writer {
     return len
   }
 
-  toArray (): number[] {
-    let ret = []
-    for (const x of this.bufs) {
-      if (x.length < 65536) { ret.push(...x) } else { ret = ret.concat(x) }
+  toArray(): number[] {
+    const totalLength = this.getLength()
+    const ret = new Array(totalLength)
+    let offset = 0
+    for (const buf of this.bufs) {
+      for (let i = 0; i < buf.length; i++) {
+        ret[offset++] = buf[i]
+      }
     }
     return ret
   }
 
-  write (buf: number[]): Writer {
+  write(buf: number[]): Writer {
     this.bufs.push(buf)
     return this
   }
 
-  writeReverse (buf: number[]): Writer {
+  writeReverse(buf: number[]): Writer {
     const buf2: number[] = new Array(buf.length)
     for (let i = 0; i < buf2.length; i++) {
       buf2[i] = buf[buf.length - 1 - i]
@@ -341,21 +345,21 @@ export class Writer {
     return this
   }
 
-  writeUInt8 (n: number): Writer {
+  writeUInt8(n: number): Writer {
     const buf = new Array(1)
     buf[0] = n
     this.write(buf)
     return this
   }
 
-  writeInt8 (n: number): Writer {
+  writeInt8(n: number): Writer {
     const buf = new Array(1)
     buf[0] = n & 0xFF
     this.write(buf)
     return this
   }
 
-  writeUInt16BE (n: number): Writer {
+  writeUInt16BE(n: number): Writer {
     this.bufs.push([
       (n >> 8) & 0xFF, // shift right 8 bits to get the high byte
       n & 0xFF // low byte is just the last 8 bits
@@ -363,11 +367,11 @@ export class Writer {
     return this
   }
 
-  writeInt16BE (n: number): Writer {
+  writeInt16BE(n: number): Writer {
     return this.writeUInt16BE(n & 0xFFFF) // Mask with 0xFFFF to get the lower 16 bits
   }
 
-  writeUInt16LE (n: number): Writer {
+  writeUInt16LE(n: number): Writer {
     this.bufs.push([
       n & 0xFF, // low byte is just the last 8 bits
       (n >> 8) & 0xFF // shift right 8 bits to get the high byte
@@ -375,11 +379,11 @@ export class Writer {
     return this
   }
 
-  writeInt16LE (n: number): Writer {
+  writeInt16LE(n: number): Writer {
     return this.writeUInt16LE(n & 0xFFFF) // Mask with 0xFFFF to get the lower 16 bits
   }
 
-  writeUInt32BE (n: number): Writer {
+  writeUInt32BE(n: number): Writer {
     this.bufs.push([
       (n >> 24) & 0xFF, // highest byte
       (n >> 16) & 0xFF,
@@ -389,11 +393,11 @@ export class Writer {
     return this
   }
 
-  writeInt32BE (n: number): Writer {
+  writeInt32BE(n: number): Writer {
     return this.writeUInt32BE(n >>> 0) // Using unsigned right shift to handle negative numbers
   }
 
-  writeUInt32LE (n: number): Writer {
+  writeUInt32LE(n: number): Writer {
     this.bufs.push([
       n & 0xFF, // lowest byte
       (n >> 8) & 0xFF,
@@ -403,41 +407,41 @@ export class Writer {
     return this
   }
 
-  writeInt32LE (n: number): Writer {
+  writeInt32LE(n: number): Writer {
     return this.writeUInt32LE(n >>> 0) // Using unsigned right shift to handle negative numbers
   }
 
-  writeUInt64BEBn (bn: BigNumber): Writer {
+  writeUInt64BEBn(bn: BigNumber): Writer {
     const buf = bn.toArray('be', 8)
     this.write(buf)
     return this
   }
 
-  writeUInt64LEBn (bn: BigNumber): Writer {
+  writeUInt64LEBn(bn: BigNumber): Writer {
     const buf = bn.toArray('be', 8)
     this.writeReverse(buf)
     return this
   }
 
-  writeUInt64LE (n: number): Writer {
+  writeUInt64LE(n: number): Writer {
     const buf = new BigNumber(n).toArray('be', 8)
     this.writeReverse(buf)
     return this
   }
 
-  writeVarIntNum (n: number): Writer {
+  writeVarIntNum(n: number): Writer {
     const buf = Writer.varIntNum(n)
     this.write(buf)
     return this
   }
 
-  writeVarIntBn (bn: BigNumber): Writer {
+  writeVarIntBn(bn: BigNumber): Writer {
     const buf = Writer.varIntBn(bn)
     this.write(buf)
     return this
   }
 
-  static varIntNum (n: number): number[] {
+  static varIntNum(n: number): number[] {
     let buf: number[]
     if (n < 253) {
       buf = [n] // 1 byte
@@ -477,7 +481,7 @@ export class Writer {
     return buf
   }
 
-  static varIntBn (bn: BigNumber): number[] {
+  static varIntBn(bn: BigNumber): number[] {
     let buf: number[]
     if (bn.ltn(253)) {
       const n = bn.toNumber()
@@ -505,70 +509,70 @@ export class Reader {
   public bin: number[]
   public pos: number
 
-  constructor (bin: number[] = [], pos: number = 0) {
+  constructor(bin: number[] = [], pos: number = 0) {
     this.bin = bin
     this.pos = pos
   }
 
-  public eof (): boolean {
+  public eof(): boolean {
     return this.pos >= this.bin.length
   }
 
-  public read (len = this.bin.length): number[] {
-    const bin = this.bin.slice(this.pos, this.pos + len)
-    this.pos = this.pos + len
-    return bin
+  public read(len = this.bin.length): number[] {
+    const start = this.pos
+    const end = this.pos + len
+    this.pos = end
+    return this.bin.slice(start, end)
   }
 
-  public readReverse (len = this.bin.length): number[] {
-    const bin = this.bin.slice(this.pos, this.pos + len)
-    this.pos = this.pos + len
-    const buf2 = new Array(bin.length)
-    for (let i = 0; i < buf2.length; i++) {
-      buf2[i] = bin[bin.length - 1 - i]
+  public readReverse(len = this.bin.length): number[] {
+    const buf2 = new Array(len)
+    for (let i = 0; i < len; i++) {
+      buf2[i] = this.bin[this.pos + len - 1 - i]
     }
+    this.pos += len
     return buf2
   }
 
-  public readUInt8 (): number {
+  public readUInt8(): number {
     const val = this.bin[this.pos]
     this.pos += 1
     return val
   }
 
-  public readInt8 (): number {
+  public readInt8(): number {
     const val = this.bin[this.pos]
     this.pos += 1
     // If the sign bit is set, convert to negative value
     return (val & 0x80) !== 0 ? val - 0x100 : val
   }
 
-  public readUInt16BE (): number {
+  public readUInt16BE(): number {
     const val = (this.bin[this.pos] << 8) | this.bin[this.pos + 1]
     this.pos += 2
     return val
   }
 
-  public readInt16BE (): number {
+  public readInt16BE(): number {
     const val = this.readUInt16BE()
     // If the sign bit is set, convert to negative value
     return (val & 0x8000) !== 0 ? val - 0x10000 : val
   }
 
-  public readUInt16LE (): number {
+  public readUInt16LE(): number {
     const val = this.bin[this.pos] | (this.bin[this.pos + 1] << 8)
     this.pos += 2
     return val
   }
 
-  public readInt16LE (): number {
+  public readInt16LE(): number {
     const val = this.readUInt16LE()
     // If the sign bit is set, convert to negative value
     const x = (val & 0x8000) !== 0 ? val - 0x10000 : val
     return x
   }
 
-  public readUInt32BE (): number {
+  public readUInt32BE(): number {
     const val =
       (this.bin[this.pos] * 0x1000000) + // Shift the first byte by 24 bits
       ((this.bin[this.pos + 1] << 16) | // Shift the second byte by 16 bits
@@ -578,13 +582,13 @@ export class Reader {
     return val
   }
 
-  public readInt32BE (): number {
+  public readInt32BE(): number {
     const val = this.readUInt32BE()
     // If the sign bit is set, convert to negative value
     return (val & 0x80000000) !== 0 ? val - 0x100000000 : val
   }
 
-  public readUInt32LE (): number {
+  public readUInt32LE(): number {
     const val =
       (this.bin[this.pos] |
         (this.bin[this.pos + 1] << 8) |
@@ -594,26 +598,26 @@ export class Reader {
     return val
   }
 
-  public readInt32LE (): number {
+  public readInt32LE(): number {
     const val = this.readUInt32LE()
     // Explicitly check if the sign bit is set and then convert to a negative value
     return (val & 0x80000000) !== 0 ? val - 0x100000000 : val
   }
 
-  public readUInt64BEBn (): BigNumber {
+  public readUInt64BEBn(): BigNumber {
     const bin = this.bin.slice(this.pos, this.pos + 8)
     const bn = new BigNumber(bin)
     this.pos = this.pos + 8
     return bn
   }
 
-  public readUInt64LEBn (): BigNumber {
+  public readUInt64LEBn(): BigNumber {
     const bin = this.readReverse(8)
     const bn = new BigNumber(bin)
     return bn
   }
 
-  public readVarIntNum (): number {
+  public readVarIntNum(): number {
     const first = this.readUInt8()
     let bn: BigNumber
     let n: number
@@ -634,7 +638,7 @@ export class Reader {
     }
   }
 
-  public readVarInt (): number[] {
+  public readVarInt(): number[] {
     const first = this.bin[this.pos]
     switch (first) {
       case 0xfd:
@@ -648,7 +652,7 @@ export class Reader {
     }
   }
 
-  public readVarIntBn (): BigNumber {
+  public readVarIntBn(): BigNumber {
     const first = this.readUInt8()
     switch (first) {
       case 0xfd:

--- a/src/script/Spend.ts
+++ b/src/script/Spend.ts
@@ -89,7 +89,7 @@ export default class Spend {
    *   inputSequence: 0xffffffff // inputSequence
    * });
    */
-  constructor (params: {
+  constructor(params: {
     sourceTXID: string
     sourceOutputIndex: number
     sourceSatoshis: number
@@ -116,7 +116,7 @@ export default class Spend {
     this.reset()
   }
 
-  reset (): void {
+  reset(): void {
     this.context = 'UnlockingScript'
     this.programCounter = 0
     this.lastCodeSeparator = null
@@ -125,7 +125,7 @@ export default class Spend {
     this.ifStack = []
   }
 
-  step (): void {
+  step(): void {
     // If the context is UnlockingScript and we have reached the end,
     // set the context to LockingScript and zero the program counter
     if (
@@ -209,7 +209,7 @@ export default class Spend {
     const padDataToSize = (buf: number[], len: number): number[] => {
       let b = buf
       while (b.length < len) {
-        b = [0x00, ...b]
+        b.unshift(0)
       }
       return b
     }
@@ -785,7 +785,7 @@ export default class Spend {
               shifted = bn1.ushrn(n)
             }
             const bufShifted = padDataToSize(
-              [...shifted.toArray().slice(buf1.length * -1)],
+              shifted.toArray().slice(buf1.length * -1),
               buf1.length
             )
             this.stack.push(bufShifted)
@@ -1288,7 +1288,7 @@ export default class Spend {
    *   console.log("Invalid spend!");
    * }
    */
-  validate (): boolean {
+  validate(): boolean {
     if (requirePushOnlyUnlockingScripts && !this.unlockingScript.isPushOnly()) {
       this.scriptEvaluationError('Unlocking scripts can only contain push operations, and no other opcodes.')
     }
@@ -1312,11 +1312,11 @@ export default class Spend {
     return true
   }
 
-  private stacktop (i: number): number[] {
+  private stacktop(i: number): number[] {
     return this.stack[this.stack.length + i]
   }
 
-  private castToBool (val: number[]): boolean {
+  private castToBool(val: number[]): boolean {
     for (let i = 0; i < val.length; i++) {
       if (val[i] !== 0) {
         // can be negative zero
@@ -1329,7 +1329,7 @@ export default class Spend {
     return false
   }
 
-  private scriptEvaluationError (str: string): void {
+  private scriptEvaluationError(str: string): void {
     throw new Error(`Script evaluation error: ${str}\n\nSource TXID: ${this.sourceTXID}\nSource output index: ${this.sourceOutputIndex}\nContext: ${this.context}\nProgram counter: ${this.programCounter}\nStack size: ${this.stack.length}\nAlt stack size: ${this.altStack.length}`)
   }
 }

--- a/src/script/Spend.ts
+++ b/src/script/Spend.ts
@@ -89,7 +89,7 @@ export default class Spend {
    *   inputSequence: 0xffffffff // inputSequence
    * });
    */
-  constructor(params: {
+  constructor (params: {
     sourceTXID: string
     sourceOutputIndex: number
     sourceSatoshis: number
@@ -116,7 +116,7 @@ export default class Spend {
     this.reset()
   }
 
-  reset(): void {
+  reset (): void {
     this.context = 'UnlockingScript'
     this.programCounter = 0
     this.lastCodeSeparator = null
@@ -125,7 +125,7 @@ export default class Spend {
     this.ifStack = []
   }
 
-  step(): void {
+  step (): void {
     // If the context is UnlockingScript and we have reached the end,
     // set the context to LockingScript and zero the program counter
     if (
@@ -207,7 +207,7 @@ export default class Spend {
     }
 
     const padDataToSize = (buf: number[], len: number): number[] => {
-      let b = buf
+      const b = buf
       while (b.length < len) {
         b.unshift(0)
       }
@@ -1288,7 +1288,7 @@ export default class Spend {
    *   console.log("Invalid spend!");
    * }
    */
-  validate(): boolean {
+  validate (): boolean {
     if (requirePushOnlyUnlockingScripts && !this.unlockingScript.isPushOnly()) {
       this.scriptEvaluationError('Unlocking scripts can only contain push operations, and no other opcodes.')
     }
@@ -1312,11 +1312,11 @@ export default class Spend {
     return true
   }
 
-  private stacktop(i: number): number[] {
+  private stacktop (i: number): number[] {
     return this.stack[this.stack.length + i]
   }
 
-  private castToBool(val: number[]): boolean {
+  private castToBool (val: number[]): boolean {
     for (let i = 0; i < val.length; i++) {
       if (val[i] !== 0) {
         // can be negative zero
@@ -1329,7 +1329,7 @@ export default class Spend {
     return false
   }
 
-  private scriptEvaluationError(str: string): void {
+  private scriptEvaluationError (str: string): void {
     throw new Error(`Script evaluation error: ${str}\n\nSource TXID: ${this.sourceTXID}\nSource output index: ${this.sourceOutputIndex}\nContext: ${this.context}\nProgram counter: ${this.programCounter}\nStack size: ${this.stack.length}\nAlt stack size: ${this.altStack.length}`)
   }
 }

--- a/src/script/Spend.ts
+++ b/src/script/Spend.ts
@@ -1016,7 +1016,7 @@ export default class Spend {
 
           try {
             sig = TransactionSignature.fromChecksigFormat(bufSig)
-            pubkey = PublicKey.fromString(toHex(bufPubkey))
+            pubkey = PublicKey.fromDER(bufPubkey)
             fSuccess = verifySignature(sig, pubkey, subscript)
           } catch (e) {
             // invalid sig or pubkey

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -62,7 +62,7 @@ export default class Transaction {
    * @param beef A binary representation of a transaction in BEEF format.
    * @returns An anchored transaction, linked to its associated inputs populated with merkle paths.
    */
-  static fromBEEF(beef: number[]): Transaction {
+  static fromBEEF (beef: number[]): Transaction {
     const reader = new Reader(beef)
     // Read the version
     const version = reader.readUInt32LE()
@@ -127,7 +127,7 @@ export default class Transaction {
    * @param ef A binary representation of a transaction in EF format.
    * @returns An extended transaction, linked to its associated inputs by locking script and satoshis amounts only.
    */
-  static fromEF(ef: number[]): Transaction {
+  static fromEF (ef: number[]): Transaction {
     const br = new Reader(ef)
     const version = br.readUInt32LE()
     if (toHex(br.read(6)) !== '0000000000ef') throw new Error('Invalid EF marker')
@@ -189,7 +189,7 @@ export default class Transaction {
    *   outputs: { vout: number, offset: number, length: number }[]
    * }
    */
-  static parseScriptOffsets(bin: number[]): {
+  static parseScriptOffsets (bin: number[]): {
     inputs: Array<{ vin: number, offset: number, length: number }>
     outputs: Array<{ vout: number, offset: number, length: number }>
   } {
@@ -215,7 +215,7 @@ export default class Transaction {
     return { inputs, outputs }
   }
 
-  static fromReader(br: Reader): Transaction {
+  static fromReader (br: Reader): Transaction {
     const version = br.readUInt32LE()
     const inputsLength = br.readVarIntNum()
     const inputs: TransactionInput[] = []
@@ -256,7 +256,7 @@ export default class Transaction {
    * @param {number[]} bin - The binary array representation of the transaction.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromBinary(bin: number[]): Transaction {
+  static fromBinary (bin: number[]): Transaction {
     const br = new Reader(bin)
     return Transaction.fromReader(br)
   }
@@ -268,7 +268,7 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHex(hex: string): Transaction {
+  static fromHex (hex: string): Transaction {
     return Transaction.fromBinary(toArray(hex, 'hex'))
   }
 
@@ -279,7 +279,7 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction EF.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHexEF(hex: string): Transaction {
+  static fromHexEF (hex: string): Transaction {
     return Transaction.fromEF(toArray(hex, 'hex'))
   }
 
@@ -290,11 +290,11 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction BEEF.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHexBEEF(hex: string): Transaction {
+  static fromHexBEEF (hex: string): Transaction {
     return Transaction.fromBEEF(toArray(hex, 'hex'))
   }
 
-  constructor(
+  constructor (
     version: number = 1,
     inputs: TransactionInput[] = [],
     outputs: TransactionOutput[] = [],
@@ -316,7 +316,7 @@ export default class Transaction {
    * @param {TransactionInput} input - The TransactionInput object to add to the transaction.
    * @throws {Error} - If the input does not have a sourceTXID or sourceTransaction defined.
    */
-  addInput(input: TransactionInput): void {
+  addInput (input: TransactionInput): void {
     if (
       typeof input.sourceTXID === 'undefined' &&
       typeof input.sourceTransaction === 'undefined'
@@ -336,7 +336,7 @@ export default class Transaction {
    *
    * @param {TransactionOutput} output - The TransactionOutput object to add to the transaction.
    */
-  addOutput(output: TransactionOutput): void {
+  addOutput (output: TransactionOutput): void {
     this.cachedHash = undefined
     this.outputs.push(output)
   }
@@ -346,7 +346,7 @@ export default class Transaction {
    *
    * @param {Record<string, any>} metadata - The metadata object to merge into the existing metadata.
    */
-  updateMetadata(metadata: Record<string, any>): void {
+  updateMetadata (metadata: Record<string, any>): void {
     this.metadata = {
       ...this.metadata,
       ...metadata
@@ -364,7 +364,7 @@ export default class Transaction {
    *
    * TODO: Benford's law change distribution.
    */
-  async fee(modelOrFee?: FeeModel | number, changeDistribution: 'equal' | 'random' = 'equal'): Promise<void> {
+  async fee (modelOrFee?: FeeModel | number, changeDistribution: 'equal' | 'random' = 'equal'): Promise<void> {
     this.cachedHash = undefined
     if (typeof modelOrFee === 'undefined') {
       modelOrFee = new SatoshisPerKilobyte(10)
@@ -425,7 +425,7 @@ export default class Transaction {
    *
    * @returns The current transaction fee
    */
-  getFee(): number {
+  getFee (): number {
     let totalIn = 0
     for (const input of this.inputs) {
       if (typeof input.sourceTransaction !== 'object') {
@@ -443,7 +443,7 @@ export default class Transaction {
   /**
    * Signs a transaction, hydrating all its unlocking scripts based on the provided script templates where they are available.
    */
-  async sign(): Promise<void> {
+  async sign (): Promise<void> {
     this.cachedHash = undefined
     for (const out of this.outputs) {
       if (typeof out.satoshis === 'undefined') {
@@ -474,7 +474,7 @@ export default class Transaction {
    * @param broadcaster The Broadcaster instance wwhere the transaction will be sent
    * @returns A BroadcastResponse or BroadcastFailure from the Broadcaster
    */
-  async broadcast(broadcaster: Broadcaster = defaultBroadcaster()): Promise<BroadcastResponse | BroadcastFailure> {
+  async broadcast (broadcaster: Broadcaster = defaultBroadcaster()): Promise<BroadcastResponse | BroadcastFailure> {
     return await broadcaster.broadcast(this)
   }
 
@@ -483,7 +483,7 @@ export default class Transaction {
    *
    * @returns {number[]} - The binary array representation of the transaction.
    */
-  toBinary(): number[] {
+  toBinary (): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(this.version)
     writer.writeVarIntNum(this.inputs.length)
@@ -515,7 +515,7 @@ export default class Transaction {
    *
    * @returns {number[]} - The BRC-30 EF representation of the transaction.
    */
-  toEF(): number[] {
+  toEF (): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(this.version)
     writer.write([0, 0, 0, 0, 0, 0xef])
@@ -555,7 +555,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction EF.
    */
-  toHexEF(): string {
+  toHexEF (): string {
     return toHex(this.toEF())
   }
 
@@ -564,7 +564,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction.
    */
-  toHex(): string {
+  toHex (): string {
     return toHex(this.toBinary())
   }
 
@@ -573,7 +573,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction BEEF.
    */
-  toHexBEEF(): string {
+  toHexBEEF (): string {
     return toHex(this.toBEEF())
   }
 
@@ -583,7 +583,7 @@ export default class Transaction {
    * @param {'hex' | undefined} enc - The encoding to use for the hash. If 'hex', returns a hexadecimal string; otherwise returns a binary array.
    * @returns {string | number[]} - The hash of the transaction in the specified format.
    */
-  hash(enc?: 'hex'): number[] | string {
+  hash (enc?: 'hex'): number[] | string {
     let hash
     if (this.cachedHash) {
       hash = this.cachedHash
@@ -602,21 +602,21 @@ export default class Transaction {
    *
    * @returns {number[]} - The ID of the transaction in the binary array format.
    */
-  id(): number[]
+  id (): number[]
   /**
    * Calculates the transaction's ID in hexadecimal format.
    *
    * @param {'hex'} enc - The encoding to use for the ID. If 'hex', returns a hexadecimal string.
    * @returns {string} - The ID of the transaction in the hex format.
    */
-  id(enc: 'hex'): string
+  id (enc: 'hex'): string
   /**
    * Calculates the transaction's ID.
    *
    * @param {'hex' | undefined} enc - The encoding to use for the ID. If 'hex', returns a hexadecimal string; otherwise returns a binary array.
    * @returns {string | number[]} - The ID of the transaction in the specified format.
    */
-  id(enc?: 'hex'): number[] | string {
+  id (enc?: 'hex'): number[] | string {
     const id = [...this.hash() as number[]]
     id.reverse()
     if (enc === 'hex') {
@@ -634,7 +634,7 @@ export default class Transaction {
    *
    * @example tx.verify(new WhatsOnChain(), new SatoshisPerKilobyte(1))
    */
-  async verify(
+  async verify (
     chainTracker: ChainTracker | 'scripts only' = defaultChainTracker(),
     feeModel?: FeeModel
   ): Promise<boolean> {
@@ -745,7 +745,7 @@ export default class Transaction {
    *
    * @returns The serialized BEEF structure
    */
-  toBEEF(): number[] {
+  toBEEF (): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(4022206465)
     const BUMPs: MerklePath[] = []

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -62,7 +62,7 @@ export default class Transaction {
    * @param beef A binary representation of a transaction in BEEF format.
    * @returns An anchored transaction, linked to its associated inputs populated with merkle paths.
    */
-  static fromBEEF (beef: number[]): Transaction {
+  static fromBEEF(beef: number[]): Transaction {
     const reader = new Reader(beef)
     // Read the version
     const version = reader.readUInt32LE()
@@ -127,7 +127,7 @@ export default class Transaction {
    * @param ef A binary representation of a transaction in EF format.
    * @returns An extended transaction, linked to its associated inputs by locking script and satoshis amounts only.
    */
-  static fromEF (ef: number[]): Transaction {
+  static fromEF(ef: number[]): Transaction {
     const br = new Reader(ef)
     const version = br.readUInt32LE()
     if (toHex(br.read(6)) !== '0000000000ef') throw new Error('Invalid EF marker')
@@ -189,7 +189,7 @@ export default class Transaction {
    *   outputs: { vout: number, offset: number, length: number }[]
    * }
    */
-  static parseScriptOffsets (bin: number[]): {
+  static parseScriptOffsets(bin: number[]): {
     inputs: Array<{ vin: number, offset: number, length: number }>
     outputs: Array<{ vout: number, offset: number, length: number }>
   } {
@@ -215,7 +215,7 @@ export default class Transaction {
     return { inputs, outputs }
   }
 
-  static fromReader (br: Reader): Transaction {
+  static fromReader(br: Reader): Transaction {
     const version = br.readUInt32LE()
     const inputsLength = br.readVarIntNum()
     const inputs: TransactionInput[] = []
@@ -256,7 +256,7 @@ export default class Transaction {
    * @param {number[]} bin - The binary array representation of the transaction.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromBinary (bin: number[]): Transaction {
+  static fromBinary(bin: number[]): Transaction {
     const br = new Reader(bin)
     return Transaction.fromReader(br)
   }
@@ -268,7 +268,7 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHex (hex: string): Transaction {
+  static fromHex(hex: string): Transaction {
     return Transaction.fromBinary(toArray(hex, 'hex'))
   }
 
@@ -279,7 +279,7 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction EF.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHexEF (hex: string): Transaction {
+  static fromHexEF(hex: string): Transaction {
     return Transaction.fromEF(toArray(hex, 'hex'))
   }
 
@@ -290,11 +290,11 @@ export default class Transaction {
    * @param {string} hex - The hexadecimal string representation of the transaction BEEF.
    * @returns {Transaction} - A new Transaction instance.
    */
-  static fromHexBEEF (hex: string): Transaction {
+  static fromHexBEEF(hex: string): Transaction {
     return Transaction.fromBEEF(toArray(hex, 'hex'))
   }
 
-  constructor (
+  constructor(
     version: number = 1,
     inputs: TransactionInput[] = [],
     outputs: TransactionOutput[] = [],
@@ -316,7 +316,7 @@ export default class Transaction {
    * @param {TransactionInput} input - The TransactionInput object to add to the transaction.
    * @throws {Error} - If the input does not have a sourceTXID or sourceTransaction defined.
    */
-  addInput (input: TransactionInput): void {
+  addInput(input: TransactionInput): void {
     if (
       typeof input.sourceTXID === 'undefined' &&
       typeof input.sourceTransaction === 'undefined'
@@ -336,7 +336,7 @@ export default class Transaction {
    *
    * @param {TransactionOutput} output - The TransactionOutput object to add to the transaction.
    */
-  addOutput (output: TransactionOutput): void {
+  addOutput(output: TransactionOutput): void {
     this.cachedHash = undefined
     this.outputs.push(output)
   }
@@ -346,7 +346,7 @@ export default class Transaction {
    *
    * @param {Record<string, any>} metadata - The metadata object to merge into the existing metadata.
    */
-  updateMetadata (metadata: Record<string, any>): void {
+  updateMetadata(metadata: Record<string, any>): void {
     this.metadata = {
       ...this.metadata,
       ...metadata
@@ -364,7 +364,7 @@ export default class Transaction {
    *
    * TODO: Benford's law change distribution.
    */
-  async fee (modelOrFee?: FeeModel | number, changeDistribution: 'equal' | 'random' = 'equal'): Promise<void> {
+  async fee(modelOrFee?: FeeModel | number, changeDistribution: 'equal' | 'random' = 'equal'): Promise<void> {
     this.cachedHash = undefined
     if (typeof modelOrFee === 'undefined') {
       modelOrFee = new SatoshisPerKilobyte(10)
@@ -425,7 +425,7 @@ export default class Transaction {
    *
    * @returns The current transaction fee
    */
-  getFee (): number {
+  getFee(): number {
     let totalIn = 0
     for (const input of this.inputs) {
       if (typeof input.sourceTransaction !== 'object') {
@@ -443,7 +443,7 @@ export default class Transaction {
   /**
    * Signs a transaction, hydrating all its unlocking scripts based on the provided script templates where they are available.
    */
-  async sign (): Promise<void> {
+  async sign(): Promise<void> {
     this.cachedHash = undefined
     for (const out of this.outputs) {
       if (typeof out.satoshis === 'undefined') {
@@ -474,7 +474,7 @@ export default class Transaction {
    * @param broadcaster The Broadcaster instance wwhere the transaction will be sent
    * @returns A BroadcastResponse or BroadcastFailure from the Broadcaster
    */
-  async broadcast (broadcaster: Broadcaster = defaultBroadcaster()): Promise<BroadcastResponse | BroadcastFailure> {
+  async broadcast(broadcaster: Broadcaster = defaultBroadcaster()): Promise<BroadcastResponse | BroadcastFailure> {
     return await broadcaster.broadcast(this)
   }
 
@@ -483,7 +483,7 @@ export default class Transaction {
    *
    * @returns {number[]} - The binary array representation of the transaction.
    */
-  toBinary (): number[] {
+  toBinary(): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(this.version)
     writer.writeVarIntNum(this.inputs.length)
@@ -515,7 +515,7 @@ export default class Transaction {
    *
    * @returns {number[]} - The BRC-30 EF representation of the transaction.
    */
-  toEF (): number[] {
+  toEF(): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(this.version)
     writer.write([0, 0, 0, 0, 0, 0xef])
@@ -555,7 +555,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction EF.
    */
-  toHexEF (): string {
+  toHexEF(): string {
     return toHex(this.toEF())
   }
 
@@ -564,7 +564,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction.
    */
-  toHex (): string {
+  toHex(): string {
     return toHex(this.toBinary())
   }
 
@@ -573,7 +573,7 @@ export default class Transaction {
    *
    * @returns {string} - The hexadecimal string representation of the transaction BEEF.
    */
-  toHexBEEF (): string {
+  toHexBEEF(): string {
     return toHex(this.toBEEF())
   }
 
@@ -583,7 +583,7 @@ export default class Transaction {
    * @param {'hex' | undefined} enc - The encoding to use for the hash. If 'hex', returns a hexadecimal string; otherwise returns a binary array.
    * @returns {string | number[]} - The hash of the transaction in the specified format.
    */
-  hash (enc?: 'hex'): number[] | string {
+  hash(enc?: 'hex'): number[] | string {
     let hash
     if (this.cachedHash) {
       hash = this.cachedHash
@@ -593,9 +593,8 @@ export default class Transaction {
     }
     if (enc === 'hex') {
       return toHex(hash)
-    } else {
-      return hash
     }
+    return hash
   }
 
   /**
@@ -603,21 +602,21 @@ export default class Transaction {
    *
    * @returns {number[]} - The ID of the transaction in the binary array format.
    */
-  id (): number[]
+  id(): number[]
   /**
    * Calculates the transaction's ID in hexadecimal format.
    *
    * @param {'hex'} enc - The encoding to use for the ID. If 'hex', returns a hexadecimal string.
    * @returns {string} - The ID of the transaction in the hex format.
    */
-  id (enc: 'hex'): string
+  id(enc: 'hex'): string
   /**
    * Calculates the transaction's ID.
    *
    * @param {'hex' | undefined} enc - The encoding to use for the ID. If 'hex', returns a hexadecimal string; otherwise returns a binary array.
    * @returns {string | number[]} - The ID of the transaction in the specified format.
    */
-  id (enc?: 'hex'): number[] | string {
+  id(enc?: 'hex'): number[] | string {
     const id = [...this.hash() as number[]]
     id.reverse()
     if (enc === 'hex') {
@@ -635,84 +634,110 @@ export default class Transaction {
    *
    * @example tx.verify(new WhatsOnChain(), new SatoshisPerKilobyte(1))
    */
-  async verify (chainTracker: ChainTracker | 'scripts only' = defaultChainTracker(), feeModel?: FeeModel): Promise<boolean> {
-    // If the transaction has a valid merkle path, verification is complete.
-    if (typeof this.merklePath === 'object') {
-      if (chainTracker === 'scripts only') {
-        return true
-      } else {
-        const proofValid = await this.merklePath.verify(
-          this.id('hex'),
-          chainTracker
-        )
-        // Note that if the proof is provided but not valid, the transaction could still be verified by proving all inputs (if they are available) and checking the associated spends.
-        if (proofValid) {
-          return true
+  async verify(
+    chainTracker: ChainTracker | 'scripts only' = defaultChainTracker(),
+    feeModel?: FeeModel
+  ): Promise<boolean> {
+    const verifiedTxids = new Set<string>()
+    const txQueue: Transaction[] = [this]
+
+    while (txQueue.length > 0) {
+      const tx = txQueue.shift()
+      const txid = tx.id('hex')
+      if (verifiedTxids.has(txid)) {
+        continue
+      }
+
+      // If the transaction has a valid merkle path, verification is complete.
+      if (typeof tx.merklePath === 'object') {
+        if (chainTracker === 'scripts only') {
+          verifiedTxids.add(txid)
+          continue
+        } else {
+          const proofValid = await tx.merklePath.verify(
+            txid,
+            chainTracker
+          )
+          // If the proof is valid, no need to verify inputs.
+          if (proofValid) {
+            verifiedTxids.add(txid)
+            continue
+          }
         }
       }
-    }
 
-    if (typeof feeModel !== 'undefined') {
-      const cpTx = Transaction.fromHexEF(this.toHexEF())
-      delete cpTx.outputs[0].satoshis
-      cpTx.outputs[0].change = true
-      await cpTx.fee(feeModel)
-      if (this.getFee() < cpTx.getFee()) throw new Error(`Verification failed because the transaction ${this.id('hex')} has an insufficient fee and has not been mined.`)
-    }
+      // Verify fee if feeModel is provided
+      if (typeof feeModel !== 'undefined') {
+        const cpTx = Transaction.fromEF(tx.toEF())
+        delete cpTx.outputs[0].satoshis
+        cpTx.outputs[0].change = true
+        await cpTx.fee(feeModel)
+        if (tx.getFee() < cpTx.getFee()) {
+          throw new Error(`Verification failed because the transaction ${txid} has an insufficient fee and has not been mined.`)
+        }
+      }
 
-    // Verify each input transaction and evaluate the spend events.
-    // Also, keep a total of the input amounts for later.
-    let inputTotal = 0
-    for (let i = 0; i < this.inputs.length; i++) {
-      const input = this.inputs[i]
-      if (typeof input.sourceTransaction !== 'object') {
-        throw new Error(`Verification failed because the input at index ${i} of transaction ${this.id('hex')} is missing an associated source transaction. This source transaction is required for transaction verification because there is no merkle proof for the transaction spending a UTXO it contains.`)
+      // Verify each input transaction and evaluate the spend events.
+      // Also, keep a total of the input amounts for later.
+      let inputTotal = 0
+      for (let i = 0; i < tx.inputs.length; i++) {
+        const input = tx.inputs[i]
+        if (typeof input.sourceTransaction !== 'object') {
+          throw new Error(`Verification failed because the input at index ${i} of transaction ${txid} is missing an associated source transaction. This source transaction is required for transaction verification because there is no merkle proof for the transaction spending a UTXO it contains.`)
+        }
+        if (typeof input.unlockingScript !== 'object') {
+          throw new Error(`Verification failed because the input at index ${i} of transaction ${txid} is missing an associated unlocking script. This script is required for transaction verification because there is no merkle proof for the transaction spending the UTXO.`)
+        }
+        const sourceOutput = input.sourceTransaction.outputs[input.sourceOutputIndex]
+        inputTotal += sourceOutput.satoshis
+
+        const sourceTxid = input.sourceTransaction.id('hex')
+        if (!verifiedTxids.has(sourceTxid)) {
+          txQueue.push(input.sourceTransaction)
+        }
+
+        const otherInputs = tx.inputs.filter((_, idx) => idx !== i)
+        if (typeof input.sourceTXID === 'undefined') {
+          input.sourceTXID = sourceTxid
+        }
+
+        const spend = new Spend({
+          sourceTXID: input.sourceTXID,
+          sourceOutputIndex: input.sourceOutputIndex,
+          lockingScript: sourceOutput.lockingScript,
+          sourceSatoshis: sourceOutput.satoshis,
+          transactionVersion: tx.version,
+          otherInputs,
+          unlockingScript: input.unlockingScript,
+          inputSequence: input.sequence,
+          inputIndex: i,
+          outputs: tx.outputs,
+          lockTime: tx.lockTime
+        })
+        const spendValid = spend.validate()
+
+        if (!spendValid) {
+          return false
+        }
       }
-      if (typeof input.unlockingScript !== 'object') {
-        throw new Error(`Verification failed because the input at index ${i} of transaction ${this.id('hex')} is missing an associated unlocking script. This script is required for transaction verification because there is no merkle proof for the transaction spending the UTXO.`)
+
+      // Total the outputs to ensure they don't amount to more than the inputs
+      let outputTotal = 0
+      for (const out of tx.outputs) {
+        if (typeof out.satoshis !== 'number') {
+          throw new Error('Every output must have a defined amount during transaction verification.')
+        }
+        outputTotal += out.satoshis
       }
-      const sourceOutput = input.sourceTransaction.outputs[input.sourceOutputIndex]
-      inputTotal += sourceOutput.satoshis
-      const inputVerified = await input.sourceTransaction.verify(chainTracker, feeModel)
-      if (!inputVerified) {
+
+      if (outputTotal > inputTotal) {
         return false
       }
-      const otherInputs = [...this.inputs]
-      otherInputs.splice(i, 1)
-      if (typeof input.sourceTXID === 'undefined') {
-        input.sourceTXID = input.sourceTransaction.id('hex')
-      }
 
-      const spend = new Spend({
-        sourceTXID: input.sourceTXID,
-        sourceOutputIndex: input.sourceOutputIndex,
-        lockingScript: sourceOutput.lockingScript,
-        sourceSatoshis: sourceOutput.satoshis,
-        transactionVersion: this.version,
-        otherInputs,
-        unlockingScript: input.unlockingScript,
-        inputSequence: input.sequence,
-        inputIndex: i,
-        outputs: this.outputs,
-        lockTime: this.lockTime
-      })
-      const spendValid = spend.validate()
-
-      if (!spendValid) {
-        return false
-      }
+      verifiedTxids.add(txid)
     }
 
-    // Total the outputs to ensure they don't amount to more than the inputs
-    let outputTotal = 0
-    for (const out of this.outputs) {
-      if (typeof out.satoshis !== 'number') {
-        throw new Error('Every output must have a defined amount during transaction verification.')
-      }
-      outputTotal += out.satoshis
-    }
-
-    return outputTotal <= inputTotal
+    return true
   }
 
   /**
@@ -720,7 +745,7 @@ export default class Transaction {
    *
    * @returns The serialized BEEF structure
    */
-  toBEEF (): number[] {
+  toBEEF(): number[] {
     const writer = new Writer()
     writer.writeUInt32LE(4022206465)
     const BUMPs: MerklePath[] = []

--- a/src/transaction/TransactionInput.ts
+++ b/src/transaction/TransactionInput.ts
@@ -59,5 +59,5 @@ export default interface TransactionInput {
     sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>
     estimateLength: (tx: Transaction, inputIndex: number) => Promise<number>
   }
-  sequence: number
+  sequence?: number
 }

--- a/src/transaction/__tests/Transaction.benchmarks.test.ts
+++ b/src/transaction/__tests/Transaction.benchmarks.test.ts
@@ -1,0 +1,222 @@
+// __tests__/transaction.benchmark.test.ts
+
+import Transaction from '../../../dist/cjs/src/transaction/Transaction'
+import PrivateKey from '../../../dist/cjs/src/primitives/PrivateKey'
+import { hash160 } from '../../../dist/cjs/src/primitives/Hash'
+import P2PKH from '../../../dist/cjs/src/script/templates/P2PKH'
+import { jest } from '@jest/globals'
+
+jest.setTimeout(60000) // Increase timeout for benchmarking tests if necessary
+
+// Helper function to measure execution time
+async function measureTime(fn: () => Promise<void>): Promise<number> {
+    const start = process.hrtime()
+    await fn()
+    const diff = process.hrtime(start)
+    const timeInMs = diff[0] * 1000 + diff[1] / 1e6
+    return timeInMs
+}
+
+describe('Transaction Verification Benchmark', () => {
+    const privateKey = new PrivateKey(1)
+    const publicKey = privateKey.toPublicKey()
+    const publicKeyHash = hash160(publicKey.toDER())
+    const p2pkh = new P2PKH()
+
+    it('verifies a transaction with a deep input chain', async () => {
+        // Create a deep chain of transactions (e.g., depth of 100)
+        const depth = 100
+        let tx = new Transaction()
+        tx.addOutput({
+            lockingScript: p2pkh.lock(publicKeyHash),
+            satoshis: 100000
+        })
+        tx.merklePath = {
+            // Mock merkle path verification
+            blockHeight: 0,
+            merkleRoot: '',
+            hashes: [],
+            verify: async () => true,
+            toBinary: () => [],
+            computeRoot: () => ''
+        }
+
+        // Build the chain
+        for (let i = 0; i < depth; i++) {
+            const newTx = new Transaction()
+            newTx.addInput({
+                sourceTransaction: tx,
+                sourceOutputIndex: 0,
+                unlockingScriptTemplate: p2pkh.unlock(privateKey),
+                sequence: 0xffffffff
+            })
+            newTx.addOutput({
+                lockingScript: p2pkh.lock(publicKeyHash),
+                satoshis: 100000 - 1000 * (i + 1)
+            })
+            await newTx.sign()
+            tx = newTx
+        }
+
+        // Measure verification time
+        const timeTaken = await measureTime(async () => {
+            const verified = await tx.verify('scripts only')
+            expect(verified).toBe(true)
+        })
+        console.log(`Verification time for deep chain of depth ${depth}: ${timeTaken.toFixed(2)} ms`)
+    })
+
+    it('verifies a transaction with a wide input set', async () => {
+        // Create a transaction with many inputs (e.g., 100 inputs)
+        const inputCount = 100
+        const sourceTxs = []
+
+        // Create source transactions
+        for (let i = 0; i < inputCount; i++) {
+            const sourceTx = new Transaction()
+            sourceTx.addOutput({
+                lockingScript: p2pkh.lock(publicKeyHash),
+                satoshis: 1000
+            })
+            sourceTx.merklePath = {
+                blockHeight: 0,
+                merkleRoot: '',
+                hashes: [],
+                verify: async () => true,
+                toBinary: () => [],
+                computeRoot: () => ''
+            }
+            sourceTxs.push(sourceTx)
+        }
+
+        // Create transaction with many inputs
+        const tx = new Transaction()
+        for (let i = 0; i < inputCount; i++) {
+            tx.addInput({
+                sourceTransaction: sourceTxs[i],
+                sourceOutputIndex: 0,
+                unlockingScriptTemplate: p2pkh.unlock(privateKey),
+                sequence: 0xffffffff
+            })
+        }
+        tx.addOutput({
+            lockingScript: p2pkh.lock(publicKeyHash),
+            satoshis: inputCount * 1000 - 1000
+        })
+        await tx.sign()
+
+        // Measure verification time
+        const timeTaken = await measureTime(async () => {
+            const verified = await tx.verify('scripts only')
+            expect(verified).toBe(true)
+        })
+        console.log(`Verification time for wide transaction with ${inputCount} inputs: ${timeTaken.toFixed(2)} ms`)
+    })
+
+    it('verifies a large transaction with many inputs and outputs', async () => {
+        const inputCount = 50
+        const outputCount = 50
+        const sourceTxs = []
+
+        // Create source transactions
+        for (let i = 0; i < inputCount; i++) {
+            const sourceTx = new Transaction()
+            sourceTx.addOutput({
+                lockingScript: p2pkh.lock(publicKeyHash),
+                satoshis: 2000
+            })
+            sourceTx.merklePath = {
+                blockHeight: 0,
+                merkleRoot: '',
+                hashes: [],
+                verify: async () => true,
+                toBinary: () => [],
+                computeRoot: () => ''
+            }
+            sourceTxs.push(sourceTx)
+        }
+
+        // Create transaction with many inputs and outputs
+        const tx = new Transaction()
+        for (let i = 0; i < inputCount; i++) {
+            tx.addInput({
+                sourceTransaction: sourceTxs[i],
+                sourceOutputIndex: 0,
+                unlockingScriptTemplate: p2pkh.unlock(privateKey),
+                sequence: 0xffffffff
+            })
+        }
+        for (let i = 0; i < outputCount; i++) {
+            tx.addOutput({
+                lockingScript: p2pkh.lock(publicKeyHash),
+                satoshis: 1000
+            })
+        }
+        await tx.sign()
+
+        // Measure verification time
+        const timeTaken = await measureTime(async () => {
+            const verified = await tx.verify('scripts only')
+            expect(verified).toBe(true)
+        })
+        console.log(`Verification time for large transaction with ${inputCount} inputs and ${outputCount} outputs: ${timeTaken.toFixed(2)} ms`)
+    })
+
+    it('verifies a transaction with nested inputs (complex graph)', async () => {
+        // Create a transaction graph where inputs come from transactions with multiple inputs
+        const depth = 5
+        const fanOut = 3
+        let txs = []
+
+        // Create base transactions
+        for (let i = 0; i < fanOut; i++) {
+            const baseTx = new Transaction()
+            baseTx.addOutput({
+                lockingScript: p2pkh.lock(publicKeyHash),
+                satoshis: 100000
+            })
+            baseTx.merklePath = {
+                blockHeight: 0,
+                merkleRoot: '',
+                hashes: [],
+                verify: async () => true,
+                toBinary: () => [],
+                computeRoot: () => ''
+            }
+            txs.push(baseTx)
+        }
+
+        // Build the graph
+        for (let d = 0; d < depth; d++) {
+            const newTxs = []
+            for (const tx of txs) {
+                const newTx = new Transaction()
+                for (let i = 0; i < fanOut; i++) {
+                    newTx.addInput({
+                        sourceTransaction: tx,
+                        sourceOutputIndex: 0,
+                        unlockingScriptTemplate: p2pkh.unlock(privateKey),
+                        sequence: 0xffffffff
+                    })
+                }
+                newTx.addOutput({
+                    lockingScript: p2pkh.lock(publicKeyHash),
+                    satoshis: tx.outputs[0].satoshis - 1000 * fanOut
+                })
+                await newTx.sign()
+                newTxs.push(newTx)
+            }
+            txs = newTxs
+        }
+
+        // Take the last transaction for verification
+        const finalTx = txs[0]
+
+        // Measure verification time
+        const timeTaken = await measureTime(async () => {
+            const verified = await finalTx.verify('scripts only')
+            expect(verified).toBe(true)
+        })
+        console.log(`Verification time for nested inputs with depth ${depth} and fan-out ${fanOut}: ${timeTaken.toFixed(2)} ms`)
+    })
+})


### PR DESCRIPTION
## Description of Changes

Refactor the verify method to make use of a queuee and only verify transactions in a given graph once, thereby increasing performance significantly.

Also, add a benchmarking suite that tests SPV verification in a number of different scenarios, enabling us to measure the impact of future changes on verification speed.

Finally, address #125 by making the sequence number optional in transaction inputs.

## Linked Issues / Tickets

Closes #125

## Testing Procedure

Added benchmarking suite. Previous to the change, it took 30,000 ms to verify the 5-deep fanout-3 transaction on my machine. After the change, it takes 1,300 ms to perform the same verification.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged