### PR TITLE
Beef implement BRC96 V2 serialization

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -866,8 +866,8 @@ export default class BeefTx {
     get tx() 
     get rawTx() 
     constructor(tx: Transaction | number[] | string, bumpIndex?: number) 
-    toWriter(writer: Writer): void 
-    static fromReader(br: Reader): BeefTx 
+    toWriter(writer: Writer, magic: number): void 
+    static fromReader(br: Reader, magic: number): BeefTx 
 }
 ```
 
@@ -899,8 +899,9 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 export class Beef {
     bumps: MerklePath[] = [];
     txs: BeefTx[] = [];
-    constructor() 
-    get version(): number 
+    version: BeefVersion = undefined;
+    constructor(version?: BeefVersion) 
+    get magic(): number 
     findTxid(txid: string): BeefTx | undefined 
     mergeBump(bump: MerklePath): number 
     mergeRawTx(rawTx: number[], bumpIndex?: number): BeefTx 
@@ -1869,6 +1870,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 | |
 | --- |
+| [BeefVersion](#type-beefversion) |
 | [Fetch](#type-fetch) |
 | [HttpClientResponse](#type-httpclientresponse) |
 
@@ -1905,6 +1907,15 @@ Makes a request to the server.
 
 ```ts
 export type Fetch = (url: string, options: FetchOptions) => Promise<Response>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Variables](#variables)
+
+---
+### Type: BeefVersion
+
+```ts
+export type BeefVersion = undefined | "V1" | "V2"
 ```
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Variables](#variables)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
## Description of Changes

Updates Beef and BeefTx classes to implement proposed BRC96 serialization format.

Implementation favors compatibility with V1 specification: Default constructed Beef serializes to V1 unless a V2 feature (txid only transaction) is used.

