### PR TITLE
ECIES ElectrumDecrypt Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
-## [1.1.27] - 2024-10-23
+## [1.1.29] - 2024-10-23
+### Fixed
+- ECIES ElectrumDecrypt counterparty decryption bug
+
+## [1.1.28] - 2024-10-23
 ### Added
 - UMD support added for use in non-standard environments.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
## Description of Changes

In the electrumDecrypt function, the following modifications were made:

- The function now checks for both compressed (33 bytes) and uncompressed (65 bytes) public keys by examining the first byte:
  - If the first byte is 0x02 or 0x03, it identifies a compressed public key (33 bytes).
  - If the first byte is 0x04, it identifies an uncompressed public key (65 bytes).
- The offset is then adjusted based on the actual length of the public key extracted. This ensures that the subsequent slicing of the ciphertext and HMAC is accurate, preventing errors during decryption.
- These changes address issues where decryption would fail with errors like "Invalid ciphertext length" or "buf length must be a multiple of 4".

## Linked Issues / Tickets

Closes #124 

## Testing Procedure

Create a test case based on example use-case which was previously failing. Now all tests pass.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged