### PR TITLE
Key linkage args fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ All notable changes to this project will be documented in this file. The format 
 ### Security
 
 ---
+
+## [1.2.6] - 2024-11-30
+### [1.2.6] Fixed
+- revealSpecificKeyLinkage requires a counterparty. 
+- ProtoWallet now correctly implements the wallet interface.
+
+---
 ## [1.2.5] - 2024-11-30
 ### [1.2.5] Added
 - Testnet capabilities & config override for node to function without error to defaultBroadcaster

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -583,10 +583,11 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 export interface RevealSpecificKeyLinkageArgs extends KeyLinkageArgs {
     verifier: PubKeyHex;
+    counterparty: WalletCounterparty;
 }
 ```
 
-See also: [KeyLinkageArgs](#interface-keylinkageargs), [PubKeyHex](#type-pubkeyhex)
+See also: [KeyLinkageArgs](#interface-keylinkageargs), [PubKeyHex](#type-pubkeyhex), [WalletCounterparty](#type-walletcounterparty)
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Variables](#variables)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/wallet/Wallet.interfaces.ts
+++ b/src/wallet/Wallet.interfaces.ts
@@ -584,6 +584,7 @@ export interface RevealCounterpartyKeyLinkageArgs {
  */
 export interface RevealSpecificKeyLinkageArgs extends KeyLinkageArgs {
   verifier: PubKeyHex
+  counterparty: WalletCounterparty
 }
 
 /**


### PR DESCRIPTION
## Description of Changes

- revealSpecificKeyLinkage requires a counterparty. 
- ProtoWallet now correctly implements the wallet interface.

## Testing Procedure

When using the ProtoWallet as param which required a Wallet, there was an error thrown that it didn't properly implement the interface. This was caused by a discrepancy in the revealSpecificKeyLinkage function counterparty arg.

- [x] All tests pass locally
- [x] I have tested manually by linking to a separate code repo.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged