### PR TITLE
Pubkey gotcha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file. The format 
     - [Removed](#removed)
     - [Fixed](#fixed)
     - [Security](#security)
+  - [\[1.2.8\] - 2024-12-02](#128---2024-12-02)
+    - [Fixed](#127-fixed)
   - [\[1.2.7\] - 2024-12-02](#127---2024-12-02)
     - [Added](#127-added)
     - [Fixed](#127-fixed)
@@ -98,6 +100,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.2.8] - 2024-12-02
+
+### [1.2.8] Fixed
+
+- Stop people inadvertently creating corrupted public keys.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/__tests/PublicKey.test.ts
+++ b/src/primitives/__tests/PublicKey.test.ts
@@ -27,6 +27,12 @@ describe('PublicKey', () => {
     })
   })
 
+  describe('Constructor', () => {
+    it('Should throw when accidentally passing in DER', () => {
+      expect(() => new PublicKey('036af279b60aa437d48bb0e2ec0b0c6b5cfaa976663f1f08ad456fd7fff149321d')).toThrow()
+    })
+  })
+
   describe('Instance methods', () => {
     test('deriveSharedSecret should derive a shared secret Point', () => {
       const sharedSecret = publicKey.deriveSharedSecret(privateKey)


### PR DESCRIPTION
## Description of Changes

Stop people from accidentally using the public key constructor when they should use `.fromString()`.

This leads to corrupted public keys but does not throw errors until later. Better to throw here, immediately, and with a clear resolution to the problem.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged