### PR TITLE
Added null check to MerklePath constructor to allow for tx.verify('sc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.2.13] - 2024-12-13
+### [1.2.13] Fixed
+
+- Fixed MerklePath constructor to allow for null initialisation.
+
 ## [1.2.12] - 2024-12-12
 ### [1.2.12] Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ All notable changes to this project will be documented in this file. The format 
 - [CHANGELOG for `@bsv/sdk`](#changelog-for-bsvsdk)
   - [Table of Contents](#table-of-contents)
   - [\[Unreleased\]](#unreleased)
-    - [Added](#added)
-      JSON HTTP substrate, with corresponding swagger-ui documentation.
-      
+    - [Added](#added)      
     - [Changed](#changed)
     - [Deprecated](#deprecated)
     - [Removed](#removed)
     - [Fixed](#fixed)
     - [Security](#security)
+  - [\[1.2.13\]](#1213---2024-12-13)
+    - [Added](#1213-added)
+    - [Fixed](#1213-fixed)
+  - [\[1.2.12\]](#1212---2024-12-12)
+    - [Fixed](#1212-fixed)
   - [\[1.2.11\]](#1211---2024-12-10)
     - [Fixed](#1211-fixed)
   - [\[1.2.10\]](#1210)
@@ -106,6 +109,16 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+## [1.2.13] - 2024-12-13
+
+### [1.2.13] Added
+- JSON HTTP substrate, with corresponding swagger-ui documentation.
+- Example args and responses to the swagger-ui
+
+### [1.2.13] Fixed
+- PrivateKey test linter errors
 
 ---
 

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1032,9 +1032,7 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWithResults:
@@ -1146,16 +1144,38 @@ components:
       properties:
         tx:
           type: array
+          examples:
+            - [1, 1, 1, 1]
           items:
             type: number
         outputs:
           type: array
+          examples:
+            - 
+              - outputIndex: 0
+                protocol: "wallet payment"
+                paymentRemittance:
+                  derivationPrefix: "12345678"
+                  derivationSuffix: "00000"
+                  senderIdentity: "02ffc4f361307f34a82069edbcbe2c9f4bd5498165549f42bdeb698ffdcab1ea38"
+              - outputIndex: 1
+                protocol: "basket insertion"
+                insertionRemittance:
+                  basket: "todo token"
+                  customInstructions: "3453,3462346,self"
+                  tags:
+                    - "foose"
+                    - "goose"
           items:
             $ref: "#/components/schemas/InternalizeOutput"
         description:
           type: string
+          examples:
+            - "Creation of a new thing."
         labels:
           type: array
+          examples:
+            - ["todo create", "productivity"]
           items:
             type: string
         seekPermission:
@@ -1280,17 +1300,13 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
         randomizeOutputs:
@@ -1341,9 +1357,7 @@ components:
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
     InternalizeOutput:
@@ -1411,7 +1425,7 @@ components:
             type: string
         version:
           type: number
-          examples:
+          examples: 
             - 1
         lockTime:
           type: number

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1048,10 +1048,19 @@ components:
       properties:
         spends:
           type: object
+          examples:
+            - 0:
+                unlockingScript: "47304402206ba4a1c0aa4e1ba7f2cd79de36..."
+                sequenceNumber: 4294967295
+              1:
+                unlockingScript: "473044022031d6c05d21ea4ee96da0fa17ea..."
+                sequenceNumber: 4294967295
           additionalProperties:
             $ref: "#/components/schemas/SignActionSpend"
         reference:
           type: string
+          examples:
+            - "C1HST7xvPKzh66npoiJ5fKwnLtnH3xxQ4ylxaGBTTOA="
         options:
           $ref: "#/components/schemas/SignActionOptions"
     SignActionResult:
@@ -1059,8 +1068,12 @@ components:
       properties:
         txid:
           type: string
+          examples:
+            - "cd8345f101b2c6163921d9ff08526d88aa24cb68456f546eec935c6485155838"
         tx:
           type: array
+          examples:
+            - [1, 1, 1, 1]
           items:
             type: number
         sendWithResults:
@@ -1292,14 +1305,18 @@ components:
         reference:
           type: string
           examples:
-            - "unique id for this transaction"
+            - "C1HST7xvPKzh66npoiJ5fKwnLtnH3xxQ4ylxaGBTTOA="
     SignActionSpend:
       type: object
       properties:
         unlockingScript:
           type: string
+          examples:
+            - "47304402206ba4a1c0aa4e1ba7f2cd79de3617c9b1..."
         sequenceNumber:
           type: number
+          examples:
+            - 4294967295
     SignActionOptions:
       type: object
       properties:
@@ -1311,6 +1328,10 @@ components:
           type: boolean
         sendWith:
           type: array
+          examples:
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
     InternalizeOutput:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -385,16 +385,24 @@ paths:
                   default: true
                 plaintext:
                   type: array
+                  examples:
+                    - [ 115, 101, 99, 114, 101, 116, 115 ]
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "extra secure"
                 counterparty:
                   type: string
+                  examples:
+                    - "self"
                 privileged:
                   type: boolean
                   default: false
@@ -408,6 +416,8 @@ paths:
                 properties:
                   ciphertext:
                     type: array
+                    examples:
+                      - [47, 102, 55, 54, 51, 52, 42, 38, 9]
                     items:
                       type: integer
         "400":
@@ -432,16 +442,24 @@ paths:
                   default: true
                 ciphertext:
                   type: array
+                  examples:
+                    - [47, 102, 55, 54, 51, 52, 42, 38, 9]
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "extra secure"
                 counterparty:
                   type: string
+                  examples:
+                    - "self"
                 privileged:
                   type: boolean
                   default: false
@@ -455,6 +473,8 @@ paths:
                 properties:
                   plaintext:
                     type: array
+                    examples:
+                      - [115, 101, 99, 114, 101, 116, 115]
                     items:
                       type: integer
         "400":
@@ -1043,9 +1063,7 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWithResults:
@@ -1164,7 +1182,8 @@ components:
         outputs:
           type: array
           examples:
-            - - outputIndex: 0
+            - 
+              - outputIndex: 0
                 protocol: "wallet payment"
                 paymentRemittance:
                   derivationPrefix: "12345678"
@@ -1334,17 +1353,13 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
         randomizeOutputs:
@@ -1395,9 +1410,7 @@ components:
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
     InternalizeOutput:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -190,14 +190,7 @@ paths:
                 identityKey:
                   type: boolean
                 protocolID:
-                  type: array
-                  examples:
-                    - [0, "todo token"]
-                  prefixItems:
-                    - type: integer
-                    - type: string
-                  minItems: 2
-                  maxItems: 2
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                   examples:
@@ -311,17 +304,22 @@ paths:
               properties:
                 counterparty:
                   type: string
+                  examples:
+                    - "027facf8e28228eea25abd69c4f23f15573e1d0f9180718af297e1458827cd5aef"
                 verifier:
                   type: string
+                  examples:
+                    - "03c378a866d72c391343eddeadf64c4f896637c4160ac6073e7b80b5717310153b"
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "special stuff"
                 privileged:
                   type: boolean
                   default: false
@@ -335,19 +333,26 @@ paths:
                 properties:
                   prover:
                     type: string
+                    examples:
+                      - "02790ab2d725d04af29e20bf46e1dbc40ba8b49f1355146884c5bd06819273d101"
                   verifier:
                     type: string
+                    examples:
+                      - "03c378a866d72c391343eddeadf64c4f896637c4160ac6073e7b80b5717310153b"
                   counterparty:
                     type: string
+                    examples:
+                      - "027facf8e28228eea25abd69c4f23f15573e1d0f9180718af297e1458827cd5aef"
+                  revelationTime:
+                    type: string
+                    examples:
+                      - "2024-12-12T12:12:12.120Z"
                   protocolID:
-                    type: array
-                    prefixItems:
-                      - type: integer
-                      - type: string
-                    minItems: 2
-                    maxItems: 2
+                    $ref: "#/components/schemas/ProtocolID"
                   keyID:
                     type: string
+                    examples:
+                      - "1"
                   encryptedLinkage:
                     type: array
                     items:
@@ -383,10 +388,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -433,10 +435,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -483,10 +482,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -537,10 +533,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -589,10 +582,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -647,10 +637,7 @@ paths:
                   items:
                     type: integer
                 protocolID:
-                  type: array
-                  items:
-                    - type: integer
-                    - type: string
+                  $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
                 privilegedReason:
@@ -1650,3 +1637,12 @@ components:
           type: array
           items:
           $ref: "#/components/schemas/AcquireCertificateResult"
+    ProtocolID:
+      type: array
+      examples:
+        - [0, "todo token"]
+      prefixItems:
+        - type: integer
+        - type: string
+      minItems: 2
+      maxItems: 2

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -191,6 +191,8 @@ paths:
                   type: boolean
                 protocolID:
                   type: array
+                  examples:
+                    - [0, "todo token"]
                   prefixItems:
                     - type: integer
                     - type: string
@@ -198,13 +200,19 @@ paths:
                   maxItems: 2
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privileged:
                   type: boolean
                   default: false
                 privilegedReason:
                   type: string
+                  examples:
+                    - "extra secure"
                 counterparty:
                   type: string
+                  examples:
+                    - "0200daf17a4b9f7ca9e188a5b0e2b356107bde46d9d358d99e3402bd0e5beffbff"
                 forSelf:
                   type: boolean
                   default: false
@@ -218,6 +226,8 @@ paths:
                 properties:
                   publicKey:
                     type: string
+                    examples:
+                      - "027facf8e28228eea25abd69c4f23f15573e1d0f9180718af297e1458827cd5aef"
         "400":
           description: Invalid input
         "500":
@@ -1032,9 +1042,7 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWithResults:
@@ -1153,7 +1161,8 @@ components:
         outputs:
           type: array
           examples:
-            - - outputIndex: 0
+            - 
+              - outputIndex: 0
                 protocol: "wallet payment"
                 paymentRemittance:
                   derivationPrefix: "12345678"
@@ -1323,17 +1332,13 @@ components:
         noSendChange:
           type: array
           examples:
-            - [
-                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
-              ]
+            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
         randomizeOutputs:
@@ -1384,9 +1389,7 @@ components:
         sendWith:
           type: array
           examples:
-            - [
-                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
-              ]
+            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
           items:
             type: string
     InternalizeOutput:
@@ -1454,7 +1457,7 @@ components:
             type: string
         version:
           type: number
-          examples:
+          examples: 
             - 1
         lockTime:
           type: number
@@ -1551,8 +1554,12 @@ components:
             type: string
     BasketStringUnder300Bytes:
       type: string
+      examples:
+        - "todo token"
     OutpointString:
       type: string
+      examples:
+        - "ae9b36d2bad995e5cd9a12e73d02140c163a7932fa37b927de1f031410dbd751.0"
     AcquireCertificateArgs:
       type: object
       properties:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -18,17 +18,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateActionArgs'
+              $ref: "#/components/schemas/CreateActionArgs"
       responses:
-        '200':
+        "200":
           description: The created transaction result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateActionResult'
-        '400':
+                $ref: "#/components/schemas/CreateActionResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /signAction:
     post:
@@ -40,17 +40,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SignActionArgs'
+              $ref: "#/components/schemas/SignActionArgs"
       responses:
-        '200':
+        "200":
           description: The signed transaction result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SignActionResult'
-        '400':
+                $ref: "#/components/schemas/SignActionResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /abortAction:
     post:
@@ -62,17 +62,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AbortActionArgs'
+              $ref: "#/components/schemas/AbortActionArgs"
       responses:
-        '200':
+        "200":
           description: The abortion result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AbortActionResult'
-        '400':
+                $ref: "#/components/schemas/AbortActionResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /listActions:
     post:
@@ -84,17 +84,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ListActionsArgs'
+              $ref: "#/components/schemas/ListActionsArgs"
       responses:
-        '200':
+        "200":
           description: The list of actions
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListActionsResult'
-        '400':
+                $ref: "#/components/schemas/ListActionsResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /internalizeAction:
     post:
@@ -106,17 +106,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InternalizeActionArgs'
+              $ref: "#/components/schemas/InternalizeActionArgs"
       responses:
-        '200':
+        "200":
           description: The internalization result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InternalizeActionResult'
-        '400':
+                $ref: "#/components/schemas/InternalizeActionResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /listOutputs:
     post:
@@ -128,17 +128,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ListOutputsArgs'
+              $ref: "#/components/schemas/ListOutputsArgs"
       responses:
-        '200':
+        "200":
           description: The list of outputs
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListOutputsResult'
-        '400':
+                $ref: "#/components/schemas/ListOutputsResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /relinquishOutput:
     post:
@@ -153,11 +153,11 @@ paths:
               type: object
               properties:
                 basket:
-                  $ref: '#/components/schemas/BasketStringUnder300Bytes'
+                  $ref: "#/components/schemas/BasketStringUnder300Bytes"
                 output:
-                  $ref: '#/components/schemas/OutpointString'
+                  $ref: "#/components/schemas/OutpointString"
       responses:
-        '200':
+        "200":
           description: The relinquishment result
           content:
             application/json:
@@ -168,9 +168,9 @@ paths:
                     type: boolean
                     examples:
                       - true
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
   /getPublicKey:
     post:
@@ -192,8 +192,8 @@ paths:
                 protocolID:
                   type: array
                   prefixItems:
-                      - type: integer
-                      - type: string
+                    - type: integer
+                    - type: string
                   minItems: 2
                   maxItems: 2
                 keyID:
@@ -209,7 +209,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The public key
           content:
             application/json:
@@ -218,9 +218,9 @@ paths:
                 properties:
                   publicKey:
                     type: string
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /revealCounterpartyKeyLinkage:
@@ -245,7 +245,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The counterparty key linkage
           content:
             application/json:
@@ -268,9 +268,9 @@ paths:
                     type: array
                     items:
                       type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /revealSpecificKeyLinkage:
@@ -302,7 +302,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The specific key linkage
           content:
             application/json:
@@ -334,9 +334,9 @@ paths:
                       type: integer
                   proofType:
                     type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /encrypt:
@@ -373,7 +373,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The encrypted data
           content:
             application/json:
@@ -384,9 +384,9 @@ paths:
                     type: array
                     items:
                       type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /decrypt:
@@ -423,7 +423,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The decrypted data
           content:
             application/json:
@@ -434,9 +434,9 @@ paths:
                     type: array
                     items:
                       type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /createHmac:
@@ -473,7 +473,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The HMAC
           content:
             application/json:
@@ -484,9 +484,9 @@ paths:
                     type: array
                     items:
                       type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /verifyHmac:
@@ -527,7 +527,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The verification result
           content:
             application/json:
@@ -536,9 +536,9 @@ paths:
                 properties:
                   valid:
                     type: boolean
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /createSignature:
@@ -579,7 +579,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The signature
           content:
             application/json:
@@ -590,9 +590,9 @@ paths:
                     type: array
                     items:
                       type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /verifySignature:
@@ -640,7 +640,7 @@ paths:
                   type: boolean
                   default: false
       responses:
-        '200':
+        "200":
           description: The verification result
           content:
             application/json:
@@ -649,9 +649,9 @@ paths:
                 properties:
                   valid:
                     type: boolean
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /acquireCertificate:
@@ -664,17 +664,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AcquireCertificateArgs'
+              $ref: "#/components/schemas/AcquireCertificateArgs"
       responses:
-        '200':
+        "200":
           description: The acquired certificate
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AcquireCertificateResult'
-        '400':
+                $ref: "#/components/schemas/AcquireCertificateResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /listCertificates:
@@ -707,15 +707,15 @@ paths:
                 privilegedReason:
                   type: string
       responses:
-        '200':
+        "200":
           description: The list of certificates
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListCertificatesResult'
-        '400':
+                $ref: "#/components/schemas/ListCertificatesResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /proveCertificate:
@@ -728,17 +728,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProveCertificateArgs'
+              $ref: "#/components/schemas/ProveCertificateArgs"
       responses:
-        '200':
+        "200":
           description: The proof of the certificate
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProveCertificateResult'
-        '400':
+                $ref: "#/components/schemas/ProveCertificateResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /relinquishCertificate:
@@ -760,7 +760,7 @@ paths:
                 certifier:
                   type: string
       responses:
-        '200':
+        "200":
           description: The relinquishment result
           content:
             application/json:
@@ -771,9 +771,9 @@ paths:
                     type: boolean
                     examples:
                       - true
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /discoverByIdentityKey:
@@ -798,15 +798,15 @@ paths:
                 offset:
                   type: integer
       responses:
-        '200':
+        "200":
           description: The discovered certificates
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DiscoverCertificatesResult'
-        '400':
+                $ref: "#/components/schemas/DiscoverCertificatesResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /discoverByAttributes:
@@ -833,15 +833,15 @@ paths:
                 offset:
                   type: integer
       responses:
-        '200':
+        "200":
           description: The discovered certificates
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DiscoverCertificatesResult'
-        '400':
+                $ref: "#/components/schemas/DiscoverCertificatesResult"
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /isAuthenticated:
@@ -850,7 +850,7 @@ paths:
         - HTTPWalletJSON
       summary: Checks if the user is authenticated
       responses:
-        '200':
+        "200":
           description: The authentication status
           content:
             application/json:
@@ -859,9 +859,9 @@ paths:
                 properties:
                   authenticated:
                     type: boolean
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /waitForAuthentication:
@@ -870,7 +870,7 @@ paths:
         - HTTPWalletJSON
       summary: Waits for user authentication
       responses:
-        '200':
+        "200":
           description: The authentication result
           content:
             application/json:
@@ -881,9 +881,9 @@ paths:
                     type: boolean
                     examples:
                       - true
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /getHeight:
@@ -892,7 +892,7 @@ paths:
         - HTTPWalletJSON
       summary: Retrieves the current blockchain height
       responses:
-        '200':
+        "200":
           description: The current blockchain height
           content:
             application/json:
@@ -901,9 +901,9 @@ paths:
                 properties:
                   height:
                     type: integer
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /getHeaderForHeight:
@@ -921,7 +921,7 @@ paths:
                 height:
                   type: integer
       responses:
-        '200':
+        "200":
           description: The block header
           content:
             application/json:
@@ -930,9 +930,9 @@ paths:
                 properties:
                   header:
                     type: string
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /getNetwork:
@@ -941,7 +941,7 @@ paths:
         - HTTPWalletJSON
       summary: Retrieves the current network
       responses:
-        '200':
+        "200":
           description: The current network
           content:
             application/json:
@@ -953,9 +953,9 @@ paths:
                     enum:
                       - mainnet
                       - testnet
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 
   /getVersion:
@@ -964,7 +964,7 @@ paths:
         - HTTPWalletJSON
       summary: Retrieves the current version
       responses:
-        '200':
+        "200":
           description: The current version
           content:
             application/json:
@@ -973,9 +973,9 @@ paths:
                 properties:
                   version:
                     type: string
-        '400':
+        "400":
           description: Invalid input
-        '500':
+        "500":
           description: Internal server error
 components:
   schemas:
@@ -984,58 +984,76 @@ components:
       properties:
         description:
           type: string
+          examples:
+            - "human readable purpose of this action"
         inputBEEF:
           type: array
+          examples:
+            - [1, 1, 1, 1]
           items:
             type: number
         inputs:
           type: array
           items:
-            $ref: '#/components/schemas/CreateActionInput'
+            $ref: "#/components/schemas/CreateActionInput"
         outputs:
           type: array
           items:
-            $ref: '#/components/schemas/CreateActionOutput'
+            $ref: "#/components/schemas/CreateActionOutput"
         lockTime:
           type: number
+          examples:
+            - 0
         version:
           type: number
+          examples:
+            - 1
         labels:
           type: array
+          examples:
+            - ["todo create"]
           items:
             type: string
         options:
-          $ref: '#/components/schemas/CreateActionOptions'
+          $ref: "#/components/schemas/CreateActionOptions"
     CreateActionResult:
       type: object
       properties:
         txid:
           type: string
+          examples:
+            - "16bed6368b8b1542cd6eb87f5bc20dc830b41a2258dde40438a75fa701d24e9a"
         tx:
           type: array
+          examples:
+            - [1, 1, 1, 1]
           items:
             type: number
         noSendChange:
           type: array
+          examples:
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWithResults:
           type: array
           items:
-            $ref: '#/components/schemas/SendWithResult'
+            $ref: "#/components/schemas/SendWithResult"
         signableTransaction:
-          $ref: '#/components/schemas/SignableTransaction'
+          $ref: "#/components/schemas/SignableTransaction"
     SignActionArgs:
       type: object
       properties:
         spends:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/SignActionSpend'
+            $ref: "#/components/schemas/SignActionSpend"
         reference:
           type: string
         options:
-          $ref: '#/components/schemas/SignActionOptions'
+          $ref: "#/components/schemas/SignActionOptions"
     SignActionResult:
       type: object
       properties:
@@ -1048,7 +1066,7 @@ components:
         sendWithResults:
           type: array
           items:
-            $ref: '#/components/schemas/SendWithResult'
+            $ref: "#/components/schemas/SendWithResult"
     AbortActionArgs:
       type: object
       properties:
@@ -1097,7 +1115,7 @@ components:
         actions:
           type: array
           items:
-            $ref: '#/components/schemas/WalletAction'
+            $ref: "#/components/schemas/WalletAction"
     InternalizeActionArgs:
       type: object
       properties:
@@ -1108,7 +1126,7 @@ components:
         outputs:
           type: array
           items:
-            $ref: '#/components/schemas/InternalizeOutput'
+            $ref: "#/components/schemas/InternalizeOutput"
         description:
           type: string
         labels:
@@ -1163,35 +1181,57 @@ components:
         outputs:
           type: array
           items:
-            $ref: '#/components/schemas/WalletOutput'
+            $ref: "#/components/schemas/WalletOutput"
     CreateActionInput:
       type: object
       properties:
         outpoint:
           type: string
+          examples:
+            - "ef01fee61a0d00090280027a0ec9df2e605fa46a903dfa1bd249b96aa3001490.0"
         inputDescription:
           type: string
+          examples:
+            - "why this token is being spent"
         unlockingScript:
           type: string
+          examples:
+            - "47304402200aa56a892e310a7575035fb3c0bcf466bbc16e97dae197cc1d40412313f94b89022011944d2b1b0fa72dbe7893c400624a0652a6efcc40d459216c0e00d5d135f7fc412103820b289317fa9ba995ca05bc084a77ae6077dbb424206424d92b51653521bb90"
         unlockingScriptLength:
           type: number
+          examples:
+            - 106
         sequenceNumber:
           type: number
+          examples:
+            - 4294967295
     CreateActionOutput:
       type: object
       properties:
         lockingScript:
           type: string
+          examples:
+            - "76a914978bf440c1ae52331b2e95b641c0041debaa87ce88ac"
         satoshis:
           type: number
+          examples:
+            - 1234
         outputDescription:
           type: string
+          examples:
+            - "why this token is being created"
         basket:
           type: string
+          examples:
+            - "todo token"
         customInstructions:
           type: string
+          examples:
+            - "invoice1234,keyId1,03820b289317fa9ba995ca05bc084a77ae6077dbb424206424d92b51653521bb90"
         tags:
           type: array
+          examples:
+            - ["todo", "productivity"]
           items:
             type: string
     CreateActionOptions:
@@ -1214,10 +1254,18 @@ components:
           type: boolean
         noSendChange:
           type: array
+          examples:
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWith:
           type: array
+          examples:
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
         randomizeOutputs:
@@ -1227,6 +1275,8 @@ components:
       properties:
         txid:
           type: string
+          examples:
+            - "a0084f73e13afdcc284cc810b4d22af004a38dcf404d8ddbe43ac9fb1a77a4be"
         status:
           type: string
           enum: [unproven, sending, failed]
@@ -1235,10 +1285,14 @@ components:
       properties:
         tx:
           type: array
+          examples:
+            - [1, 1, 1, 1]
           items:
             type: number
         reference:
           type: string
+          examples:
+            - "unique id for this transaction"
     SignActionSpend:
       type: object
       properties:
@@ -1296,7 +1350,16 @@ components:
           type: number
         status:
           type: string
-          enum: [completed, unprocessed, sending, unproven, unsigned, nosend, nonfinal]
+          enum:
+            [
+              completed,
+              unprocessed,
+              sending,
+              unproven,
+              unsigned,
+              nosend,
+              nonfinal,
+            ]
         isOutgoing:
           type: boolean
         description:
@@ -1312,11 +1375,11 @@ components:
         inputs:
           type: array
           items:
-            $ref: '#/components/schemas/WalletActionInput'
+            $ref: "#/components/schemas/WalletActionInput"
         outputs:
           type: array
           items:
-            $ref: '#/components/schemas/WalletActionOutput'
+            $ref: "#/components/schemas/WalletActionOutput"
     WalletActionInput:
       type: object
       properties:
@@ -1419,7 +1482,7 @@ components:
         certificates:
           type: array
           items:
-          $ref: '#/components/schemas/AcquireCertificateResult'
+          $ref: "#/components/schemas/AcquireCertificateResult"
     ProveCertificateArgs:
       type: object
       properties:
@@ -1446,4 +1509,4 @@ components:
         certificates:
           type: array
           items:
-          $ref: '#/components/schemas/AcquireCertificateResult'
+          $ref: "#/components/schemas/AcquireCertificateResult"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1009,10 +1009,16 @@ paths:
               properties:
                 type:
                   type: string
+                  examples:
+                    - "W/iqV/xaa8VH3s8cxttj8Q3rVaPGxd9JfWMfs9leGr8="
                 serialNumber:
                   type: string
+                  examples:
+                    - "oXTshKWy209Lv8MFVDxmsFzZQQ"
                 certifier:
                   type: string
+                  examples:
+                    - "03d40063722f77cc57a96bdf963c56fd29085b1297e598471ad63dd51b1b54db6e"
       responses:
         "200":
           description: The relinquishment result

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1810,8 +1810,8 @@ components:
         type:
           type: string
           examples:
-            - "passport check"
-        attributes:
+            - "W/iqV/xaa8VH3s8cxttj8Q3rVaPGxd9JfWMfs9leGr8="
+        fields:
           type: object
           examples:
             - firstName: "Michael"
@@ -1829,18 +1829,38 @@ components:
     AcquireCertificateResult:
       type: object
       properties:
-        certifier:
-          type: string
         type:
           type: string
+          examples:
+            - "W/iqV/xaa8VH3s8cxttj8Q3rVaPGxd9JfWMfs9leGr8="
+        subject:
+          type: string
+          examples:
+            - "02d292971b665575c90e8183e20d7c528e2ec1734fcb9f69c7e65e5046596767f3"
         serialNumber:
           type: string
-        attributes:
+          examples:
+            - "6d4U5qznZnQmWJF3sEqKXsi5pB8sUhD0MWcadrxzKas="
+        certifier:
+          type: string
+          examples:
+            - "035836f24728af22bdeb3524c35b2e6c6126a45587dd11fcab826c054e170f97b8"
+        revocationOutput:
+          type: string
+          examples:
+            - "e38a285d99d8a70448240255b5e92090bef87d7c5abab34a1263966fcde40621.3"
+        signature:
+          type: string
+          examples:
+            - "30450221008a9e150a43dc22652f4b627d08cae1d..."
+        fields:
           type: object
+          examples:
+            - firstName: "Michael"
+              lastName: "Huntington"
+              dob: "12/12/2001"
           additionalProperties:
             type: string
-        issuanceTime:
-          type: string
         expirationTime:
           type: string
     ListCertificatesResult:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1085,6 +1085,8 @@ components:
       properties:
         reference:
           type: string
+          examples:
+            - "C1HST7xvPKzh66npoiJ5fKwnLtnH3xxQ4ylxaGBTTOA="
     AbortActionResult:
       type: object
       properties:
@@ -1097,6 +1099,8 @@ components:
       properties:
         labels:
           type: array
+          examples:
+            - ["todo create"]
           items:
             type: string
         labelQueryMode:
@@ -1104,6 +1108,8 @@ components:
           enum: [any, all]
         includeLabels:
           type: boolean
+          examples:
+            - false
         includeInputs:
           type: boolean
         includeInputSourceLockingScripts:
@@ -1116,8 +1122,12 @@ components:
           type: boolean
         limit:
           type: number
+          examples:
+            - 10
         offset:
           type: number
+          examples:
+            - 0
         seekPermission:
           type: boolean
     ListActionsResult:
@@ -1125,6 +1135,8 @@ components:
       properties:
         totalActions:
           type: number
+          examples:
+            - 1
         actions:
           type: array
           items:
@@ -1367,8 +1379,12 @@ components:
       properties:
         txid:
           type: string
+          examples:
+            - "ab69c16801e6ea2bb78bde521c6e3654f7e665d0900e4236b5945e47a1482d3c"
         satoshis:
           type: number
+          examples:
+            - 1
         status:
           type: string
           enum:
@@ -1385,12 +1401,18 @@ components:
           type: boolean
         description:
           type: string
+          examples:
+            - "The creation of a token which captures an item of a todo list."
         labels:
           type: array
+          examples:
+            - ["todo create"]
           items:
             type: string
         version:
           type: number
+          examples:
+            - 1
         lockTime:
           type: number
         inputs:
@@ -1406,37 +1428,63 @@ components:
       properties:
         sourceOutpoint:
           type: string
+          examples:
+            - "50e7365af507f6c862b6ca77cef2571ae63544bcd8e19c3c2abc44b20d0aeb6c.3"
         sourceSatoshis:
           type: number
+          examples:
+            - 4000
         sourceLockingScript:
           type: string
+          examples:
+            - "76a9144f427ee5f3099f0ac571f6b723a628e7b08fb64c88ac"
         unlockingScript:
           type: string
+          examples:
+            - "47304402200aa56a892e310a7575035fb3c0bcf4..."
         inputDescription:
           type: string
+          examples:
+            - "spending of a token of some sort"
         sequenceNumber:
           type: number
+          examples:
+            - 4294967295
     WalletActionOutput:
       type: object
       properties:
         satoshis:
           type: number
+          examples:
+            - 1000
         lockingScript:
           type: string
+          examples:
+            - "76a914dd8b1abde0304820ace0adf1478a3ef2291a833788ac"
         spendable:
           type: boolean
         customInstructions:
           type: string
+          examples:
+            - "invoice5678,keyId2,02ffc4f361307f34a82069edbcbe2c9f4bd5498165549f42bdeb698ffdcab1ea38"
         tags:
           type: array
+          examples:
+            - ["todo create", "productivity"]
           items:
             type: string
         outputIndex:
           type: number
+          examples:
+            - 0
         outputDescription:
           type: string
+          examples:
+            - "a special token of some description"
         basket:
           type: string
+          examples:
+            - "todo token"
     WalletOutput:
       type: object
       properties:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -247,10 +247,16 @@ paths:
               properties:
                 counterparty:
                   type: string
+                  examples:
+                    - "027facf8e28228eea25abd69c4f23f15573e1d0f9180718af297e1458827cd5aef"
                 verifier:
                   type: string
+                  examples:
+                    - "03c378a866d72c391343eddeadf64c4f896637c4160ac6073e7b80b5717310153b"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "extra sensitive"
                 privileged:
                   type: boolean
                   default: false
@@ -264,12 +270,20 @@ paths:
                 properties:
                   prover:
                     type: string
+                    examples:
+                      - "02790ab2d725d04af29e20bf46e1dbc40ba8b49f1355146884c5bd06819273d101"
                   verifier:
                     type: string
+                    examples:
+                      - "03c378a866d72c391343eddeadf64c4f896637c4160ac6073e7b80b5717310153b"
                   counterparty:
                     type: string
+                    examples:
+                      - "027facf8e28228eea25abd69c4f23f15573e1d0f9180718af297e1458827cd5aef"
                   revelationTime:
                     type: string
+                    examples:
+                      - "2024-12-12T12:12:12.120Z"
                   encryptedLinkage:
                     type: array
                     items:
@@ -1042,7 +1056,9 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWithResults:
@@ -1161,8 +1177,7 @@ components:
         outputs:
           type: array
           examples:
-            - 
-              - outputIndex: 0
+            - - outputIndex: 0
                 protocol: "wallet payment"
                 paymentRemittance:
                   derivationPrefix: "12345678"
@@ -1332,13 +1347,17 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
         randomizeOutputs:
@@ -1389,7 +1408,9 @@ components:
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
     InternalizeOutput:
@@ -1457,7 +1478,7 @@ components:
             type: string
         version:
           type: number
-          examples: 
+          examples:
             - 1
         lockTime:
           type: number

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1048,15 +1048,19 @@ paths:
             schema:
               type: object
               properties:
+                identityKey:
+                  type: string
+                  examples:
+                    - "03ed91c6e33a5ef6fc3d927b2d7064af0c78447cfc304c069715ea7bdd2e5c6ea8"
+                limit:
+                  type: integer
+                  examples:
+                    - 10
+                offset:
+                  type: integer
                 seekPermission:
                   type: boolean
                   default: true
-                identityKey:
-                  type: string
-                limit:
-                  type: integer
-                offset:
-                  type: integer
       responses:
         "200":
           description: The discovered certificates
@@ -1081,17 +1085,21 @@ paths:
             schema:
               type: object
               properties:
-                seekPermission:
-                  type: boolean
-                  default: true
                 attributes:
                   type: object
+                  examples:
+                    - firstName: "David"
                   additionalProperties:
                     type: string
                 limit:
                   type: integer
+                  examples:
+                    - 10
                 offset:
                   type: integer
+                seekPermission:
+                  type: boolean
+                  default: true
       responses:
         "200":
           description: The discovered certificates
@@ -1927,6 +1935,8 @@ components:
       properties:
         totalCertificates:
           type: number
+          examples:
+            - 1
         certificates:
           type: array
           items:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -934,14 +934,23 @@ paths:
               properties:
                 certifiers:
                   type: array
+                  examples:
+                    - - "0322f8f64b95234a4b531109c2c271e01cd2a9ee497e71a788cae384b6aae54d75"
+                      - "02e3dfb8196c17baab7353e139693a1c0813d60ecd022f5c52779faf2cff341374"
+                      - "0334b3dd693269d37e0ef35aace5dc07fdd510ff0f1596399ed7bf8b27dc025bdd"
                   items:
                     type: string
                 types:
                   type: array
+                  examples:
+                    - - "60Tlwe2P7yCqOvGh1zfMQJSjGCPQh8y11oGrlrbi/z4="
+                      - "xrhnMvBJoy7tWi92bFzci3cGNhmiC+yU8iK8vSSeZWI="
                   items:
                     type: string
                 limit:
                   type: integer
+                  examples:
+                    - 10
                 offset:
                   type: integer
                 privileged:
@@ -949,6 +958,8 @@ paths:
                   default: false
                 privilegedReason:
                   type: string
+                  examples:
+                    - "-"
       responses:
         "200":
           description: The list of certificates
@@ -1871,7 +1882,7 @@ components:
         certificates:
           type: array
           items:
-          $ref: "#/components/schemas/AcquireCertificateResult"
+            $ref: "#/components/schemas/AcquireCertificateResult"
     ProveCertificateArgs:
       type: object
       properties:
@@ -1898,7 +1909,7 @@ components:
         certificates:
           type: array
           items:
-          $ref: "#/components/schemas/AcquireCertificateResult"
+            $ref: "#/components/schemas/AcquireCertificateResult"
     ProtocolID:
       type: array
       examples:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1032,7 +1032,9 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWithResults:
@@ -1151,8 +1153,7 @@ components:
         outputs:
           type: array
           examples:
-            - 
-              - outputIndex: 0
+            - - outputIndex: 0
                 protocol: "wallet payment"
                 paymentRemittance:
                   derivationPrefix: "12345678"
@@ -1192,12 +1193,18 @@ components:
       properties:
         basket:
           type: string
+          examples:
+            - "todo token"
         tags:
           type: array
+          examples:
+            - ["todo create", "todo burn"]
           items:
             type: string
         tagQueryMode:
           type: string
+          examples:
+            - "any"
           enum: [all, any]
         include:
           type: string
@@ -1210,15 +1217,31 @@ components:
           type: boolean
         limit:
           type: number
+          examples:
+            - 10
         offset:
           type: number
         seekPermission:
           type: boolean
     ListOutputsResult:
       type: object
+      examples:
+        - totalOutputs: 1
+          outputs:
+            - satoshis: 1000
+              lockingScript: "76a914dd8b1abde0304820ace0adf1478a3ef2291a833788ac"
+              spendable: true
+              customInstructions: "12,34,023398754239872342354534"
+              tags: ["todo create"]
+              outpoint: "d834139537caeb6abb876e1adcf00064fa7a775cf324a2c3bd8c13a8ec8c888f.34"
+              labels: ["productivity"]
+        - totalOutputs: 1
+          BEEF: [2, 0, 190, 239]
       properties:
         totalOutputs:
           type: number
+          examples:
+            - 1
         BEEF:
           type: array
           items:
@@ -1300,13 +1323,17 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
         randomizeOutputs:
@@ -1357,7 +1384,9 @@ components:
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
     InternalizeOutput:
@@ -1425,7 +1454,7 @@ components:
             type: string
         version:
           type: number
-          examples: 
+          examples:
             - 1
         lockTime:
           type: number

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -681,20 +681,30 @@ paths:
                   default: true
                 data:
                   type: array
+                  examples:
+                    - [115, 101, 99, 114, 101, 116, 115]
                   items:
                     type: integer
                 hashToDirectlySign:
                   type: array
+                  examples:
+                    - []
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "I love to be secure"
                 counterparty:
                   type: string
+                  examples:
+                    - "anyone"
                 privileged:
                   type: boolean
                   default: false
@@ -736,20 +746,134 @@ paths:
                     type: integer
                 hashToDirectlyVerify:
                   type: array
+                  examples:
+                    - [
+                        114,
+                        178,
+                        137,
+                        236,
+                        120,
+                        224,
+                        169,
+                        40,
+                        197,
+                        101,
+                        72,
+                        10,
+                        67,
+                        84,
+                        83,
+                        227,
+                        10,
+                        203,
+                        146,
+                        237,
+                        219,
+                        59,
+                        120,
+                        255,
+                        22,
+                        139,
+                        40,
+                        115,
+                        124,
+                        246,
+                        168,
+                        73,
+                      ]
                   items:
                     type: integer
                 signature:
                   type: array
+                  examples:
+                    - [
+                        48,
+                        69,
+                        2,
+                        33,
+                        0,
+                        189,
+                        197,
+                        179,
+                        187,
+                        162,
+                        114,
+                        42,
+                        69,
+                        21,
+                        51,
+                        96,
+                        183,
+                        226,
+                        242,
+                        212,
+                        49,
+                        221,
+                        96,
+                        197,
+                        178,
+                        63,
+                        241,
+                        43,
+                        248,
+                        36,
+                        212,
+                        243,
+                        226,
+                        144,
+                        198,
+                        47,
+                        238,
+                        2,
+                        32,
+                        54,
+                        138,
+                        29,
+                        195,
+                        78,
+                        4,
+                        222,
+                        220,
+                        219,
+                        226,
+                        234,
+                        189,
+                        122,
+                        78,
+                        27,
+                        129,
+                        253,
+                        196,
+                        59,
+                        189,
+                        167,
+                        195,
+                        66,
+                        73,
+                        69,
+                        115,
+                        126,
+                        200,
+                        16,
+                        65,
+                        114,
+                        64,
+                        65,
+                      ]
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
                 counterparty:
                   type: string
+                  examples:
+                    - "anyone"
                 forSelf:
                   type: boolean
                   default: false

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -914,7 +914,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AcquireCertificateResult"
+                $ref: "#/components/schemas/Certificate"
         "400":
           description: Invalid input
         "500":
@@ -943,7 +943,7 @@ paths:
                 types:
                   type: array
                   examples:
-                    - - "60Tlwe2P7yCqOvGh1zfMQJSjGCPQh8y11oGrlrbi/z4="
+                    - - "W/iqV/xaa8VH3s8cxttj8Q3rVaPGxd9JfWMfs9leGr8="
                       - "xrhnMvBJoy7tWi92bFzci3cGNhmiC+yU8iK8vSSeZWI="
                   items:
                     type: string
@@ -1837,7 +1837,7 @@ components:
         privileged:
           type: boolean
           default: false
-    AcquireCertificateResult:
+    Certificate:
       type: object
       properties:
         type:
@@ -1872,35 +1872,50 @@ components:
               dob: "12/12/2001"
           additionalProperties:
             type: string
-        expirationTime:
-          type: string
     ListCertificatesResult:
       type: object
       properties:
         totalCertificates:
           type: number
+          examples:
+            - 1
         certificates:
           type: array
           items:
-            $ref: "#/components/schemas/AcquireCertificateResult"
+            $ref: "#/components/schemas/Certificate"
     ProveCertificateArgs:
       type: object
       properties:
-        certifier:
-          type: string
-        type:
-          type: string
-        serialNumber:
-          type: string
-        proof:
+        certificate:
+          $ref: "#/components/schemas/Certificate"
+        fieldsToReveal:
           type: array
           items:
-            type: integer
+            type: string
+            examples:
+              - "dob"
+        verifier:
+          type: string
+          examples:
+            - "02a3ffa2ea5db22192aed65131a6683c0f626fb35a8c717c783587e08a4daec380"
+        privileged:
+          type: boolean
+          default: false
+        privilegedReason:
+          type: string
+          examples:
+            - "-"
     ProveCertificateResult:
       type: object
       properties:
-        valid:
-          type: boolean
+        keyringForVerifier:
+          type: object
+          examples:
+            - firstName: "ZGF2aWQ="
+              lastName: "SW52ZXJuZXNz"
+              dob: "MTIvMTIvMTk4OA=="
+          additionalProperties:
+            type: string
     DiscoverCertificatesResult:
       type: object
       properties:
@@ -1909,7 +1924,7 @@ components:
         certificates:
           type: array
           items:
-            $ref: "#/components/schemas/AcquireCertificateResult"
+            $ref: "#/components/schemas/Certificate"
     ProtocolID:
       type: array
       examples:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1169,6 +1169,8 @@ paths:
                 properties:
                   height:
                     type: integer
+                    examples:
+                      - 875002
         "400":
           description: Invalid input
         "500":
@@ -1188,6 +1190,8 @@ paths:
               properties:
                 height:
                   type: integer
+                  examples:
+                    - 875002
       responses:
         "200":
           description: The block header
@@ -1198,6 +1202,8 @@ paths:
                 properties:
                   header:
                     type: string
+                    examples:
+                      - "0020372d395bfcfc03b467e747f873da7e4f4fd0afcc89301787b10a0000000000000000724ab3c241848b826766b46947e008e022b95877629498ec3e7dd85f1ae0b383f8f8826566280d184b11f02a"
         "400":
           description: Invalid input
         "500":
@@ -1241,6 +1247,8 @@ paths:
                 properties:
                   version:
                     type: string
+                    examples:
+                      - "BSVA-1.0.0"
         "400":
           description: Invalid input
         "500":

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -870,6 +870,8 @@ paths:
                     - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "-"
                 counterparty:
                   type: string
                   examples:
@@ -1803,14 +1805,24 @@ components:
       properties:
         certifier:
           type: string
+          examples:
+            - "035836f24728af22bdeb3524c35b2e6c6126a45587dd11fcab826c054e170f97b8"
         type:
           type: string
+          examples:
+            - "passport check"
         attributes:
           type: object
+          examples:
+            - firstName: "Michael"
+              lastName: "Huntington"
+              dob: "12/12/2001"
           additionalProperties:
             type: string
         privilegedReason:
           type: string
+          examples:
+            - "-"
         privileged:
           type: boolean
           default: false

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -386,7 +386,7 @@ paths:
                 plaintext:
                   type: array
                   examples:
-                    - [ 115, 101, 99, 114, 101, 116, 115 ]
+                    - [115, 101, 99, 114, 101, 116, 115]
                   items:
                     type: integer
                 protocolID:
@@ -499,16 +499,24 @@ paths:
                   default: true
                 data:
                   type: array
+                  examples:
+                    - [115, 101, 99, 114, 101, 116, 115]
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "2"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "special reasons"
                 counterparty:
                   type: string
+                  examples:
+                    - "anyone"
                 privileged:
                   type: boolean
                   default: false
@@ -522,6 +530,41 @@ paths:
                 properties:
                   hmac:
                     type: array
+                    examples:
+                      - [
+                          114,
+                          178,
+                          137,
+                          236,
+                          120,
+                          224,
+                          169,
+                          40,
+                          197,
+                          101,
+                          72,
+                          10,
+                          67,
+                          84,
+                          83,
+                          227,
+                          10,
+                          203,
+                          146,
+                          237,
+                          219,
+                          59,
+                          120,
+                          255,
+                          22,
+                          139,
+                          40,
+                          115,
+                          124,
+                          246,
+                          168,
+                          73,
+                        ]
                     items:
                       type: integer
         "400":
@@ -546,20 +589,63 @@ paths:
                   default: true
                 data:
                   type: array
+                  examples:
+                    - [115, 101, 99, 114, 101, 116, 115]
                   items:
                     type: integer
                 hmac:
                   type: array
+                  examples:
+                    - [
+                        114,
+                        178,
+                        137,
+                        236,
+                        120,
+                        224,
+                        169,
+                        40,
+                        197,
+                        101,
+                        72,
+                        10,
+                        67,
+                        84,
+                        83,
+                        227,
+                        10,
+                        203,
+                        146,
+                        237,
+                        219,
+                        59,
+                        120,
+                        255,
+                        22,
+                        139,
+                        40,
+                        115,
+                        124,
+                        246,
+                        168,
+                        73,
+                      ]
                   items:
                     type: integer
                 protocolID:
                   $ref: "#/components/schemas/ProtocolID"
                 keyID:
                   type: string
+                  examples:
+                    - "1"
                 privilegedReason:
                   type: string
+                  examples:
+                    - "I love to be secure"
                 counterparty:
                   type: string
+                  examples:
+                    - "anyone"
                 privileged:
                   type: boolean
                   default: false
@@ -1063,7 +1149,9 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWithResults:
@@ -1182,8 +1270,7 @@ components:
         outputs:
           type: array
           examples:
-            - 
-              - outputIndex: 0
+            - - outputIndex: 0
                 protocol: "wallet payment"
                 paymentRemittance:
                   derivationPrefix: "12345678"
@@ -1353,13 +1440,17 @@ components:
         noSendChange:
           type: array
           examples:
-            - ["11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0"]
+            - [
+                "11df9f39662e276dc2f637f063919ce3ca86cbc2d55ee8d661408d22b1f49018.0",
+              ]
           items:
             type: string
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
         randomizeOutputs:
@@ -1410,7 +1501,9 @@ components:
         sendWith:
           type: array
           examples:
-            - ["c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606"]
+            - [
+                "c2d37dd0575766e4deedf7ba072ad35b87e9223af01d2829a81960ba7164f606",
+              ]
           items:
             type: string
     InternalizeOutput:

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -135,7 +135,7 @@ This interface defines a standard method for broadcasting transactions.
 ```ts
 export interface Broadcaster {
     broadcast: (transaction: Transaction) => Promise<BroadcastResponse | BroadcastFailure>;
-    broadcastMany?: (txs: Transaction[]) => Promise<Array<object>>;
+    broadcastMany?: (txs: Transaction[]) => Promise<object[]>;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
   "name": "@bsv/sdk",
+<<<<<<< HEAD
   "version": "1.2.12",
+=======
+  "version": "1.2.13",
+>>>>>>> 38128b0 (1.2.13)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
+<<<<<<< HEAD
       "version": "1.2.12",
+=======
+      "version": "1.2.13",
+>>>>>>> 38128b0 (1.2.13)
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/__tests/PrivateKey.test.ts
+++ b/src/primitives/__tests/PrivateKey.test.ts
@@ -11,9 +11,9 @@ describe('PrivateKey', () => {
     BRC42Private.forEach((vector, index) => {
       it(`Passes BRC42 private vector #${index + 1}`, () => {
         const publicKey = PublicKey.fromString(vector.senderPublicKey)
-        const privateKey = PrivateKey.fromString(vector.recipientPrivateKey, 16)
+        const privateKey = PrivateKey.fromString(vector.recipientPrivateKey)
         const derived = privateKey.deriveChild(publicKey, vector.invoiceNumber)
-        expect(derived.toHex(32)).toEqual(vector.privateKey)
+        expect(derived.toHex()).toEqual(vector.privateKey)
       })
     })
   })

--- a/src/transaction/MerklePath.ts
+++ b/src/transaction/MerklePath.ts
@@ -129,7 +129,7 @@ export default class MerklePath {
 
     let root: string
     // every txid must calculate to the same root.
-    this.path[0].map((leaf, idx) => {
+    this.path[0]?.map((leaf, idx) => {
       if (idx === 0) root = this.computeRoot(leaf.hash)
       if (root !== this.computeRoot(leaf.hash)) {
         throw new Error('Mismatched roots')

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -12,7 +12,7 @@ import Spend from '../script/Spend.js'
 import ChainTracker from './ChainTracker.js'
 import { defaultBroadcaster } from './broadcasters/DefaultBroadcaster.js'
 import { defaultChainTracker } from './chaintrackers/DefaultChainTracker.js'
-import { BEEF_MAGIC } from './Beef.js'
+import { ATOMIC_BEEF, BEEF_MAGIC } from './Beef.js'
 
 /**
  * Represents a complete Bitcoin transaction. This class encapsulates all the details
@@ -119,8 +119,8 @@ export default class Transaction {
     const reader = new Reader(beef)
     // Read the Atomic BEEF prefix
     const prefix = reader.readUInt32LE()
-    if (prefix !== 0x01010101) {
-      throw new Error(`Invalid Atomic BEEF prefix. Expected 0x01010101, received ${prefix.toString(16)}.`)
+    if (prefix !== ATOMIC_BEEF) {
+      throw new Error(`Invalid Atomic BEEF prefix. Expected 0x01010101, received 0x${prefix.toString(16)}.`)
     }
 
     // Read the subject TXID


### PR DESCRIPTION
…ripts only') to process

## Description of Changes

In order to use tx.verify whilst bypassing the merkle-proof check one can specify 'scripts only' to `tx.verify('scripts only')`& set `tx.merklePath `to an empty `new MerklePath(0,[])` but the constructor will fail without this tiny modification.

## Linked Issues / Tickets

-

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged