### PR TITLE
Chore/binary conformity

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -214,8 +214,8 @@ export default class Certificate {
     fields: Record<CertificateFieldNameUnder50Bytes, string>;
     signature?: HexString;
     constructor(type: Base64String, serialNumber: Base64String, subject: PubKeyHex, certifier: PubKeyHex, revocationOutpoint: OutpointString, fields: Record<CertificateFieldNameUnder50Bytes, string>, signature?: HexString) 
-    toBin(includeSignature: boolean = true): number[] 
-    static fromBin(bin: number[]): Certificate 
+    toBinary(includeSignature: boolean = true): number[] 
+    static fromBinary(bin: number[]): Certificate 
     async verify(): Promise<boolean> 
     async sign(certifier: Wallet): Promise<void> 
 }
@@ -316,12 +316,12 @@ type: Base64String
 ```
 See also: [Base64String](#type-base64string)
 
-#### Method fromBin
+#### Method fromBinary
 
 Deserializes a certificate from binary format.
 
 ```ts
-static fromBin(bin: number[]): Certificate 
+static fromBinary(bin: number[]): Certificate 
 ```
 See also: [Certificate](#class-certificate)
 
@@ -348,12 +348,12 @@ Argument Details
 + **certifier**
   + The wallet representing the certifier.
 
-#### Method toBin
+#### Method toBinary
 
 Serializes the certificate into binary format, with or without a signature.
 
 ```ts
-toBin(includeSignature: boolean = true): number[] 
+toBinary(includeSignature: boolean = true): number[] 
 ```
 
 Returns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.2.21",
+      "version": "1.2.22",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/certificates/Certificate.ts
+++ b/src/auth/certificates/Certificate.ts
@@ -85,7 +85,7 @@ export default class Certificate {
    * @param {boolean} [includeSignature=true] - Whether to include the signature in the serialization.
    * @returns {number[]} - The serialized certificate in binary format.
    */
-  toBin(includeSignature: boolean = true): number[] {
+  toBinary(includeSignature: boolean = true): number[] {
     const writer = new Utils.Writer()
 
     // Write type (Base64String, 32 bytes)
@@ -141,7 +141,7 @@ export default class Certificate {
    * @param {number[]} bin - The binary data representing the certificate.
    * @returns {Certificate} - The deserialized Certificate object.
    */
-  static fromBin(bin: number[]): Certificate {
+  static fromBinary(bin: number[]): Certificate {
     const reader = new Utils.Reader(bin)
 
     // Read type
@@ -210,7 +210,7 @@ export default class Certificate {
   async verify(): Promise<boolean> {
     // A verifier can be any wallet capable of verifying signatures
     const verifier = new ProtoWallet('anyone')
-    const verificationData = this.toBin(false) // Exclude the signature from the verification data
+    const verificationData = this.toBinary(false) // Exclude the signature from the verification data
 
     const { valid } = await verifier.verifySignature({
       signature: Utils.toArray(this.signature, 'hex'),
@@ -229,7 +229,7 @@ export default class Certificate {
    * @returns {Promise<void>}
    */
   async sign(certifier: Wallet): Promise<void> {
-    const preimage = this.toBin(false) // Exclude the signature when signing
+    const preimage = this.toBinary(false) // Exclude the signature when signing
     const { signature } = await certifier.createSignature({
       data: preimage,
       protocolID: [2, 'certificate signature'],

--- a/src/auth/certificates/__tests/Certificate.test.ts
+++ b/src/auth/certificates/__tests/Certificate.test.ts
@@ -49,8 +49,8 @@ describe('Certificate', () => {
       undefined // No signature
     )
 
-    const serialized = certificate.toBin(false) // Exclude signature
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(false) // Exclude signature
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.type).toEqual(sampleType)
     expect(deserializedCertificate.serialNumber).toEqual(sampleSerialNumber)
@@ -76,8 +76,8 @@ describe('Certificate', () => {
     const certifierWallet = new ProtoWallet(sampleCertifierPrivateKey)
     await certificate.sign(certifierWallet)
 
-    const serialized = certificate.toBin(true) // Include signature
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(true) // Include signature
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.type).toEqual(sampleType)
     expect(deserializedCertificate.serialNumber).toEqual(sampleSerialNumber)
@@ -176,8 +176,8 @@ describe('Certificate', () => {
     await certificate.sign(certifierWallet)
 
     // Serialize and deserialize
-    const serialized = certificate.toBin(true)
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(true)
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.fields).toEqual(sampleFieldsEmpty)
 
@@ -198,8 +198,8 @@ describe('Certificate', () => {
     )
 
     // Serialize without signature
-    const serialized = certificate.toBin(false)
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(false)
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.signature).toBeUndefined() // Signature should be empty
     expect(deserializedCertificate.fields).toEqual(sampleFields)
@@ -227,8 +227,8 @@ describe('Certificate', () => {
     await certificate.sign(certifierWallet)
 
     // Serialize and deserialize
-    const serialized = certificate.toBin(true)
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(true)
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.fields).toEqual(fields)
 
@@ -248,8 +248,8 @@ describe('Certificate', () => {
       undefined // No signature
     )
 
-    const serialized = certificate.toBin(false)
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(false)
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.revocationOutpoint).toEqual(sampleRevocationOutpoint)
   })
@@ -270,8 +270,8 @@ describe('Certificate', () => {
     await certificate.sign(certifierWallet)
 
     // Serialize and deserialize
-    const serialized = certificate.toBin(true)
-    const deserializedCertificate = Certificate.fromBin(serialized)
+    const serialized = certificate.toBinary(true)
+    const deserializedCertificate = Certificate.fromBinary(serialized)
 
     expect(deserializedCertificate.fields).toEqual({})
 

--- a/src/wallet/substrates/WalletWireProcessor.ts
+++ b/src/wallet/substrates/WalletWireProcessor.ts
@@ -1571,7 +1571,7 @@ export default class WalletWireProcessor implements WalletWire {
               acquireResult.fields,
               acquireResult.signature
             )
-            const certBin = cert.toBin()
+            const certBin = cert.toBinary()
 
             // Return success code and certificate binary
             const responseWriter = new Utils.Writer()
@@ -1651,7 +1651,7 @@ export default class WalletWireProcessor implements WalletWire {
                 cert.fields,
                 cert.signature
               )
-              const certBin = certificate.toBin()
+              const certBin = certificate.toBinary()
 
               // Write certificate binary length and data
               resultWriter.writeVarIntNum(certBin.length)
@@ -1961,7 +1961,7 @@ export default class WalletWireProcessor implements WalletWire {
         cert.fields,
         cert.signaturre
       )
-      const certBin = certificate.toBin()
+      const certBin = certificate.toBinary()
 
       // Write certificate binary length and data
       resultWriter.writeVarIntNum(certBin.length)

--- a/src/wallet/substrates/WalletWireTransceiver.ts
+++ b/src/wallet/substrates/WalletWireTransceiver.ts
@@ -1153,7 +1153,7 @@ export default class WalletWireTransceiver implements Wallet {
     }
 
     const result = await this.transmit('acquireCertificate', originator, paramWriter.toArray())
-    const cert = Certificate.fromBin(result)
+    const cert = Certificate.fromBinary(result)
     return {
       ...cert,
       signature: cert.signature as string
@@ -1214,7 +1214,7 @@ export default class WalletWireTransceiver implements Wallet {
     for (let i = 0; i < totalCertificates; i++) {
       const certificateLength = resultReader.readVarIntNum()
       const certificateBin = resultReader.read(certificateLength)
-      const cert = Certificate.fromBin(certificateBin)
+      const cert = Certificate.fromBinary(certificateBin)
       certificates.push({
         ...cert,
         signature: cert.signature as string
@@ -1328,7 +1328,7 @@ export default class WalletWireTransceiver implements Wallet {
     for (let i = 0; i < totalCertificates; i++) {
       const certBinLen = resultReader.readVarIntNum()
       const certBin = resultReader.read(certBinLen)
-      const cert = Certificate.fromBin(certBin)
+      const cert = Certificate.fromBinary(certBin)
       const nameLength = resultReader.readVarIntNum()
       const name = Utils.toUTF8(resultReader.read(nameLength))
       const iconUrlLength = resultReader.readVarIntNum()


### PR DESCRIPTION
## Description of Changes

Lots of classes have a instance.toBinary() and .fromBinary() methods. Certificates should be the same. No reason to diverge from this common pattern calling them toBin and fromBin. 

CHORE = no functional change. Just renaming a method.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged