### PR TITLE
Last Session Persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.2.23 - 2025-01-09](#1223---2025-01-09)
 - [1.2.22 - 2025-01-06](#1222---2025-01-06)
 - [1.2.21 - 2025-01-03](#1221---2025-01-03)
 - [1.2.19 - 2024-12-19](#1219---2024-12-19)
@@ -64,6 +65,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.2.23] - 2025-01-09
+
+### Added
+
+- Support for last session persistence in Peer
 
 ---
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -459,7 +459,7 @@ and sending and receiving general messages over a transport layer.
 export class Peer {
     public sessionManager: SessionManager;
     certificatesToRequest: RequestedCertificateSet;
-    constructor(wallet: Wallet, transport: Transport, certificatesToRequest?: RequestedCertificateSet, sessionManager?: SessionManager) 
+    constructor(wallet: Wallet, transport: Transport, certificatesToRequest?: RequestedCertificateSet, sessionManager?: SessionManager, autoPersistLastSession?: boolean) 
     async toPeer(message: number[], identityKey?: string, maxWaitTime?: number): Promise<void> 
     async requestCertificates(certificatesToRequest: RequestedCertificateSet, identityKey?: string, maxWaitTime = 10000): Promise<void> 
     async getAuthenticatedSession(identityKey?: string, maxWaitTime?: number): Promise<PeerSession> 
@@ -485,7 +485,7 @@ See also: [AuthMessage](#interface-authmessage), [PeerSession](#interface-peerse
 Creates a new Peer instance
 
 ```ts
-constructor(wallet: Wallet, transport: Transport, certificatesToRequest?: RequestedCertificateSet, sessionManager?: SessionManager) 
+constructor(wallet: Wallet, transport: Transport, certificatesToRequest?: RequestedCertificateSet, sessionManager?: SessionManager, autoPersistLastSession?: boolean) 
 ```
 See also: [RequestedCertificateSet](#interface-requestedcertificateset), [SessionManager](#class-sessionmanager), [Transport](#interface-transport), [Wallet](#interface-wallet)
 
@@ -499,6 +499,8 @@ Argument Details
   + Optional set of certificates to request from a peer during the initial handshake.
 + **sessionManager**
   + Optional SessionManager to be used for managing peer sessions.
++ **autoPersistLastSession**
+  + Whether to auto-persist the session with the last-interacted-with peer. Defaults to true.
 
 #### Method getAuthenticatedSession
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.2.22",
+      "version": "1.2.23",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/Peer.ts
+++ b/src/auth/Peer.ts
@@ -24,6 +24,12 @@ export class Peer {
   // Single shared counter for all callback types
   private callbackIdCounter: number = 0
 
+  // Whether to auto-persist the session with the last-interacted-with peer
+  private autoPersistLastSession: boolean = true
+
+  // Last-interacted-with peer identity key
+  private lastInteractedWithPeer: string | undefined
+
   /**
    * Creates a new Peer instance
    *
@@ -31,18 +37,25 @@ export class Peer {
    * @param {Transport} transport - The transport mechanism used for sending and receiving messages.
    * @param {RequestedCertificateSet} [certificatesToRequest] - Optional set of certificates to request from a peer during the initial handshake.
    * @param {SessionManager} [sessionManager] - Optional SessionManager to be used for managing peer sessions.
+   * @param {boolean} [autoPersistLastSession] - Whether to auto-persist the session with the last-interacted-with peer. Defaults to true.
    */
-  constructor (
+  constructor(
     wallet: Wallet,
     transport: Transport,
     certificatesToRequest?: RequestedCertificateSet,
-    sessionManager?: SessionManager
+    sessionManager?: SessionManager,
+    autoPersistLastSession?: boolean
   ) {
     this.wallet = wallet
     this.transport = transport
     this.certificatesToRequest = certificatesToRequest ?? { certifiers: [], types: {} }
     this.transport.onData(this.handleIncomingMessage.bind(this))
     this.sessionManager = sessionManager || new SessionManager()
+    if (autoPersistLastSession === false) {
+      this.autoPersistLastSession = false
+    } else {
+      this.autoPersistLastSession = true
+    }
   }
 
   /**
@@ -53,7 +66,10 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if the message fails to send.
    */
-  async toPeer (message: number[], identityKey?: string, maxWaitTime?: number): Promise<void> {
+  async toPeer(message: number[], identityKey?: string, maxWaitTime?: number): Promise<void> {
+    if (this.autoPersistLastSession && this.lastInteractedWithPeer && typeof identityKey !== 'string') {
+      identityKey = this.lastInteractedWithPeer
+    }
     const peerSession = await this.getAuthenticatedSession(identityKey, maxWaitTime)
 
     // Prepare the general message
@@ -95,7 +111,7 @@ export class Peer {
   * @returns {Promise<void>} Resolves if the certificate request message is successfully sent.
   * @throws Will throw an error if the peer session is not authenticated or if sending the request fails.
   */
-  async requestCertificates (certificatesToRequest: RequestedCertificateSet, identityKey?: string, maxWaitTime = 10000): Promise<void> {
+  async requestCertificates(certificatesToRequest: RequestedCertificateSet, identityKey?: string, maxWaitTime = 10000): Promise<void> {
     const peerSession = await this.getAuthenticatedSession(identityKey, maxWaitTime)
 
     // Prepare the general message
@@ -136,7 +152,7 @@ export class Peer {
    * @returns {Promise<PeerSession>} - A promise that resolves with an authenticated `PeerSession`.
    * @throws {Error} - Throws an error if the transport is not connected or if the handshake fails.
    */
-  async getAuthenticatedSession (identityKey?: string, maxWaitTime?: number): Promise<PeerSession> {
+  async getAuthenticatedSession(identityKey?: string, maxWaitTime?: number): Promise<PeerSession> {
     if (!this.transport) {
       throw new Error('Peer transport is not connected!')
     }
@@ -159,7 +175,7 @@ export class Peer {
    * @param {(senderPublicKey: string, payload: number[]) => void} callback - The function to call when a general message is received.
    * @returns {number} The ID of the callback listener.
    */
-  listenForGeneralMessages (callback: (senderPublicKey: string, payload: number[]) => void): number {
+  listenForGeneralMessages(callback: (senderPublicKey: string, payload: number[]) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onGeneralMessageReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -170,7 +186,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the callback to remove.
    */
-  stopListeningForGeneralMessages (callbackID: number): void {
+  stopListeningForGeneralMessages(callbackID: number): void {
     this.onGeneralMessageReceivedCallbacks.delete(callbackID)
   }
 
@@ -180,7 +196,7 @@ export class Peer {
    * @param {(certs: VerifiableCertificate[]) => void} callback - The function to call when certificates are received.
    * @returns {number} The ID of the callback listener.
    */
-  listenForCertificatesReceived (callback: (senderPublicKey: string, certs: VerifiableCertificate[]) => void): number {
+  listenForCertificatesReceived(callback: (senderPublicKey: string, certs: VerifiableCertificate[]) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onCertificatesReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -191,7 +207,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the certificates received callback to cancel.
    */
-  stopListeningForCertificatesReceived (callbackID: number): void {
+  stopListeningForCertificatesReceived(callbackID: number): void {
     this.onCertificatesReceivedCallbacks.delete(callbackID)
   }
 
@@ -201,7 +217,7 @@ export class Peer {
    * @param {(requestedCertificates: RequestedCertificateSet) => void} callback - The function to call when a certificate request is received
    * @returns {number} The ID of the callback listener.
    */
-  listenForCertificatesRequested (callback: (senderPublicKey: string, requestedCertificates: RequestedCertificateSet) => void): number {
+  listenForCertificatesRequested(callback: (senderPublicKey: string, requestedCertificates: RequestedCertificateSet) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onCertificateRequestReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -212,7 +228,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the requested certificates callback to cancel.
    */
-  stopListeningForCertificatesRequested (callbackID: number): void {
+  stopListeningForCertificatesRequested(callbackID: number): void {
     this.onCertificateRequestReceivedCallbacks.delete(callbackID)
   }
 
@@ -223,7 +239,7 @@ export class Peer {
    * @param {string} [identityKey] - The identity public key of the peer.
    * @returns {Promise<string>} A promise that resolves to the session nonce.
    */
-  private async initiateHandshake (identityKey?: string, maxWaitTime = 10000): Promise<string> {
+  private async initiateHandshake(identityKey?: string, maxWaitTime = 10000): Promise<string> {
     const sessionNonce = await createNonce(this.wallet) // Initial request nonce
     this.sessionManager.addSession({
       isAuthenticated: false,
@@ -249,7 +265,7 @@ export class Peer {
    * @param {string} sessionNonce - The session nonce created in the initial request.
    * @returns {Promise<string>} A promise that resolves with the session nonce when the initial response is received.
    */
-  private async waitForInitialResponse (sessionNonce: string, maxWaitTime = 10000): Promise<string> {
+  private async waitForInitialResponse(sessionNonce: string, maxWaitTime = 10000): Promise<string> {
     return await new Promise((resolve, reject) => {
       const callbackID = this.listenForInitialResponse(sessionNonce, (sessionNonce) => {
         clearTimeout(timeoutHandle)
@@ -272,7 +288,7 @@ export class Peer {
    * @param {(sessionNonce: string) => void} callback - The callback to invoke when the initial response is received.
    * @returns {number} The ID of the callback listener.
    */
-  private listenForInitialResponse (sessionNonce: string, callback: (sessionNonce: string) => void) {
+  private listenForInitialResponse(sessionNonce: string, callback: (sessionNonce: string) => void) {
     const callbackID = this.callbackIdCounter++
     this.onInitialResponseReceivedCallbacks.set(callbackID, { callback, sessionNonce })
     return callbackID
@@ -284,7 +300,7 @@ export class Peer {
    * @private
    * @param {number} callbackID - The ID of the callback to remove.
    */
-  private stopListeningForInitialResponses (callbackID: number) {
+  private stopListeningForInitialResponses(callbackID: number) {
     this.onInitialResponseReceivedCallbacks.delete(callbackID)
   }
 
@@ -294,7 +310,7 @@ export class Peer {
    * @param {AuthMessage} message - The incoming message to process.
    * @returns {Promise<void>}
    */
-  private async handleIncomingMessage (message: AuthMessage): Promise<void> {
+  private async handleIncomingMessage(message: AuthMessage): Promise<void> {
     if (!message.version || message.version !== AUTH_VERSION) {
       console.error(`Invalid message auth version! Received: ${message.version}, expected: ${AUTH_VERSION}`)
       return
@@ -327,7 +343,7 @@ export class Peer {
    * @param {AuthMessage} message - The incoming initial request message.
    * @returns {Promise<void>}
    */
-  async processInitialRequest (message: AuthMessage) {
+  async processInitialRequest(message: AuthMessage) {
     if (!message.identityKey || !message.initialNonce) {
       throw new Error('Missing required fields in initialResponse message.')
     }
@@ -374,6 +390,11 @@ export class Peer {
       signature
     }
 
+    // For security, only set the last-interacted-with peer here if this is the first peer we've interacted with.
+    if (!this.lastInteractedWithPeer) {
+      this.lastInteractedWithPeer = message.identityKey
+    }
+
     await this.transport.send(initialResponseMessage)
   }
 
@@ -385,7 +406,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processInitialResponse (message: AuthMessage) {
+  private async processInitialResponse(message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Initial response nonce verification failed from peer: ${message.identityKey}`)
@@ -426,6 +447,8 @@ export class Peer {
       )
     }
 
+    this.lastInteractedWithPeer = message.identityKey
+
     this.onInitialResponseReceivedCallbacks.forEach((entry) => {
       if (entry && entry.sessionNonce === peerSession.sessionNonce) {
         entry.callback(peerSession.sessionNonce)
@@ -455,7 +478,7 @@ export class Peer {
    * @param {AuthMessage} message - The certificate request message received from the peer.
    * @throws {Error} Throws an error if nonce verification fails, or the message signature is invalid.
    */
-  private async processCertificateRequest (message: AuthMessage) {
+  private async processCertificateRequest(message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Unable to verify nonce for certificate request message from: ${message.identityKey}`)
@@ -497,7 +520,7 @@ export class Peer {
    *
    * @throws {Error} Throws an error if the peer session could not be authenticated or if message signing fails.
    */
-  async sendCertificateResponse (
+  async sendCertificateResponse(
     verifierIdentityKey: string,
     certificates: VerifiableCertificate[]
   ) {
@@ -536,7 +559,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processCertificateResponse (
+  private async processCertificateResponse(
     message: AuthMessage
   ) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
@@ -574,7 +597,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processGeneralMessage (message: AuthMessage) {
+  private async processGeneralMessage(message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Unable to verify nonce for general message from: ${message.identityKey}`)
@@ -592,6 +615,8 @@ export class Peer {
     if (!valid) {
       throw new Error(`Invalid signature in generalMessage from ${peerSession.peerIdentityKey}`)
     }
+
+    this.lastInteractedWithPeer = message.identityKey
 
     this.onGeneralMessageReceivedCallbacks.forEach(callback => {
       callback(message.identityKey, message.payload)


### PR DESCRIPTION
## Description of Changes

By persisting the last-interacted-with peer, we can avoid unnecessary handshakes without requiring application code to track peer identity keys when only one foreign peer exists over a given transport.

Support for talking to multiple peers, or broadcasting for anyone, over a transport is still maintained, because you can still specify a foreign identity key in the `.toPeer()` call. However, rather than assuming a new session needs to be started by default, we now assume, if a previous interaction has occurred, that messages are destined for the same recipient.

## Linked Issues / Tickets

None

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged