### PR TITLE
[OPINION] drop the length byte on certificate signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.3 - 2025-01-13](#133---2025-01-13)
 - [1.3.2 - 2025-01-13](#132---2025-01-13)
 - [1.3.1 - 2025-01-13](#131---2025-01-13)
 - [1.3.0 - 2025-01-11](#130---2025-01-11)
@@ -68,6 +69,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.3.3] - 2025-01-13
+
+### Changed
+
+- Removed unnecessary length byte of signatures in the encoding of a Certificate in Binary.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/certificates/Certificate.ts
+++ b/src/auth/certificates/Certificate.ts
@@ -6,7 +6,8 @@ import {
   HexString,
   OutpointString,
   CertificateFieldNameUnder50Bytes,
-  ProtoWallet
+  ProtoWallet,
+  Signature
 } from '../../../mod.js'
 
 /**
@@ -128,7 +129,6 @@ export default class Certificate {
     // Write signature if included
     if (includeSignature && this.signature && this.signature.length > 0) {
       const signatureBytes = Utils.toArray(this.signature, 'hex')
-      writer.writeVarIntNum(signatureBytes.length)
       writer.write(signatureBytes)
     }
 
@@ -186,9 +186,9 @@ export default class Certificate {
     // Read signature if present
     let signature: string | undefined
     if (!reader.eof()) {
-      const signatureLength = reader.readVarIntNum()
-      const signatureBytes = reader.read(signatureLength)
-      signature = Utils.toHex(signatureBytes)
+      const signatureBytes = reader.read()
+      const sig = Signature.fromDER(signatureBytes)
+      signature = sig.toString('hex') as string
     }
 
     return new Certificate(

--- a/src/wallet/substrates/__tests/WalletWire.integration.test.ts
+++ b/src/wallet/substrates/__tests/WalletWire.integration.test.ts
@@ -1361,7 +1361,7 @@ describe('WalletWire Integration Tests', () => {
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         certifier: '02' + 'b'.repeat(64),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         fields: {
           field1: 'value1',
           field2: 'value2'
@@ -1383,7 +1383,7 @@ describe('WalletWire Integration Tests', () => {
         },
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         keyringRevealer: 'certifier',
         keyringForSubject: {}
       }
@@ -1405,7 +1405,7 @@ describe('WalletWire Integration Tests', () => {
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         certifier: '02' + 'b'.repeat(64),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         fields: {
           field1: 'value1',
           field2: 'value2'
@@ -1427,7 +1427,7 @@ describe('WalletWire Integration Tests', () => {
         },
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         keyringRevealer: 'certifier' as 'certifier',
         keyringForSubject: {
           field1: Utils.toBase64([0x01, 0x02, 0x03]),
@@ -1453,7 +1453,7 @@ describe('WalletWire Integration Tests', () => {
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         certifier: '02' + 'b'.repeat(64),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         fields: {
           field1: 'value1',
           field2: 'value2'
@@ -1476,7 +1476,7 @@ describe('WalletWire Integration Tests', () => {
         },
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-        signature: '00',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         keyringRevealer: keyringRevealerPubKey,
         keyringForSubject: {
           field1: Utils.toBase64([0x01, 0x02, 0x03]),
@@ -1502,7 +1502,7 @@ describe('WalletWire Integration Tests', () => {
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         certifier: '02' + 'b'.repeat(64),
         revocationOutpoint: 'cafebabedeadbeefcafebabedeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.1',
-        signature: '01',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         fields: {
           field3: 'value3',
           field4: 'value4'
@@ -1543,7 +1543,7 @@ describe('WalletWire Integration Tests', () => {
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         certifier: '02' + 'b'.repeat(64),
         revocationOutpoint: 'beadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbead.2',
-        signature: '02',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         fields: {
           field5: 'value5'
         }
@@ -1563,7 +1563,7 @@ describe('WalletWire Integration Tests', () => {
         },
         serialNumber: Utils.toBase64(new Array(32).fill(2)),
         revocationOutpoint: 'beadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbead.2',
-        signature: '02',
+        signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
         keyringRevealer: 'certifier' as 'certifier',
         keyringForSubject: {} // Empty keyring
       }
@@ -1592,7 +1592,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {
               field1: 'value1',
               field2: 'value2'
@@ -1629,7 +1629,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {
               field1: 'value1',
               field2: 'value2'
@@ -1641,7 +1641,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe.1',
-            signature: '01',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {
               field3: 'value3',
               field4: 'value4',
@@ -1688,7 +1688,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'e'.repeat(64),
             revocationOutpoint: 'cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe.2',
-            signature: '03',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {
               field6: 'value6'
             }
@@ -1738,7 +1738,7 @@ describe('WalletWire Integration Tests', () => {
           serialNumber: Utils.toBase64(new Array(32).fill(2)),
           certifier: '02' + 'b'.repeat(64),
           revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-          signature: '00',
+          signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
           fields: {
             field1: 'value1',
             field2: 'value2'
@@ -1772,7 +1772,7 @@ describe('WalletWire Integration Tests', () => {
           serialNumber: Utils.toBase64(new Array(32).fill(2)),
           certifier: '02' + 'b'.repeat(64),
           revocationOutpoint: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.0',
-          signature: '00',
+          signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
           fields: {
             field1: 'value1',
             field2: 'value2',
@@ -1806,7 +1806,7 @@ describe('WalletWire Integration Tests', () => {
           serialNumber: Utils.toBase64(new Array(32).fill(2)),
           certifier: '02' + 'b'.repeat(64),
           revocationOutpoint: 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe.1',
-          signature: '01',
+          signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
           fields: {
             field4: 'value4',
             field5: 'value5'
@@ -1917,7 +1917,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Test Certifier',
@@ -1958,7 +1958,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Test Certifier',
@@ -2001,7 +2001,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Certifier One',
@@ -2022,7 +2022,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'c'.repeat(64),
             revocationOutpoint: 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe.1',
-            signature: '01',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Certifier Two',
@@ -2070,7 +2070,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'b'.repeat(64),
             revocationOutpoint: 'deadbeef20248806deadbeef20248806deadbeef20248806deadbeef20248806.0',
-            signature: '00',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Test Certifier',
@@ -2128,7 +2128,7 @@ describe('WalletWire Integration Tests', () => {
             serialNumber: Utils.toBase64(new Array(32).fill(2)),
             certifier: '02' + 'e'.repeat(64),
             revocationOutpoint: 'beadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbeadbead.2',
-            signature: '02',
+            signature: '3045022100e4d03d959697ed191f9ef7ae7deacd3118b8693d18da0fd76e4ad92664ce05cf02200d753951e766cbf2d2b306e08921c06341d2de67ab75389bf84caf954ee40e88',
             fields: {},
             certifierInfo: {
               name: 'Certifier Three',


### PR DESCRIPTION
## Description of Changes

Unnecessary length byte can be dropped. BREAKING CHANGE (from 1.2.22)

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged