### PR TITLE
Instanceof revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.8 - 2025-01-20](#138---2025-01-20)
 - [1.3.7 - 2025-01-18](#137---2025-01-18)
 - [1.3.6 - 2025-01-17](#136---2025-01-17)
 - [1.3.4 - 2025-01-17](#134---2025-01-17)
@@ -72,6 +73,12 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+## [1.3.8] - 2025-01-20
+
+### Fixed
+
+- Do not use `instanceof` check in the ProtoWallet constructor, it was not reliable in real-world usage.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/wallet/ProtoWallet.ts
+++ b/src/wallet/ProtoWallet.ts
@@ -38,26 +38,26 @@ const privilegedError = new Error('ProtoWallet is a single-keyring wallet, opera
 export class ProtoWallet implements ProtoWalletApi {
   keyDeriver: KeyDeriverApi
 
-  constructor (rootKeyOrKeyDeriver: PrivateKey | 'anyone' | KeyDeriverApi) {
-    if (!(rootKeyOrKeyDeriver instanceof KeyDeriver)) {
+  constructor(rootKeyOrKeyDeriver: PrivateKey | 'anyone' | KeyDeriverApi) {
+    if (typeof (rootKeyOrKeyDeriver as KeyDeriver).identityKey !== 'string') {
       rootKeyOrKeyDeriver = new KeyDeriver(rootKeyOrKeyDeriver as PrivateKey | 'anyone')
     }
     this.keyDeriver = rootKeyOrKeyDeriver as KeyDeriver
   }
 
-  async isAuthenticated (args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<AuthenticatedResult> {
+  async isAuthenticated(args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<AuthenticatedResult> {
     return { authenticated: true }
   }
 
-  async waitForAuthentication (args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<AuthenticatedResult> {
+  async waitForAuthentication(args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<AuthenticatedResult> {
     return { authenticated: true }
   }
 
-  async getNetwork (args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<GetNetworkResult> {
+  async getNetwork(args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<GetNetworkResult> {
     return { network: 'mainnet' }
   }
 
-  async getVersion (args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<GetVersionResult> {
+  async getVersion(args: {}, Originator?: OriginatorDomainNameStringUnder250Bytes): Promise<GetVersionResult> {
     return { version: 'proto-1.0.0' }
   }
 
@@ -66,13 +66,13 @@ export class ProtoWallet implements ProtoWalletApi {
    * @param originator
    * @returns `await this.getPublicKey({ identityKey: true }, originator)`
    */
-  async getIdentityKey (
+  async getIdentityKey(
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<{ publicKey: PubKeyHex }> {
     return await this.getPublicKey({ identityKey: true }, originator)
   }
 
-  async getPublicKey (
+  async getPublicKey(
     args: GetPublicKeyArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<{ publicKey: PubKeyHex }> {
@@ -98,7 +98,7 @@ export class ProtoWallet implements ProtoWalletApi {
     }
   }
 
-  async revealCounterpartyKeyLinkage (
+  async revealCounterpartyKeyLinkage(
     args: RevealCounterpartyKeyLinkageArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<RevealCounterpartyKeyLinkageResult> {
@@ -136,7 +136,7 @@ export class ProtoWallet implements ProtoWalletApi {
     }
   }
 
-  async revealSpecificKeyLinkage (
+  async revealSpecificKeyLinkage(
     args: RevealSpecificKeyLinkageArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<RevealSpecificKeyLinkageResult> {
@@ -173,7 +173,7 @@ export class ProtoWallet implements ProtoWalletApi {
     }
   }
 
-  async encrypt (
+  async encrypt(
     args: WalletEncryptArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<WalletEncryptResult> {
@@ -188,7 +188,7 @@ export class ProtoWallet implements ProtoWalletApi {
     return { ciphertext: key.encrypt(args.plaintext) as number[] }
   }
 
-  async decrypt (
+  async decrypt(
     args: WalletDecryptArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<WalletDecryptResult> {
@@ -203,7 +203,7 @@ export class ProtoWallet implements ProtoWalletApi {
     return { plaintext: key.decrypt(args.ciphertext) as number[] }
   }
 
-  async createHmac (
+  async createHmac(
     args: CreateHmacArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<CreateHmacResult> {
@@ -218,7 +218,7 @@ export class ProtoWallet implements ProtoWalletApi {
     return { hmac: Hash.sha256hmac(key.toArray(), args.data) }
   }
 
-  async verifyHmac (
+  async verifyHmac(
     args: VerifyHmacArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<VerifyHmacResult> {
@@ -239,7 +239,7 @@ export class ProtoWallet implements ProtoWalletApi {
     return { valid }
   }
 
-  async createSignature (
+  async createSignature(
     args: CreateSignatureArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<CreateSignatureResult> {
@@ -258,7 +258,7 @@ export class ProtoWallet implements ProtoWalletApi {
     return { signature: ECDSA.sign(new BigNumber(hash), key, true).toDER() as number[] }
   }
 
-  async verifySignature (
+  async verifySignature(
     args: VerifySignatureArgs,
     originator?: OriginatorDomainNameStringUnder250Bytes
   ): Promise<VerifySignatureResult> {


### PR DESCRIPTION
## Description of Changes

Reverting use of `instanceof` in ProtoWallet's constructor — in real environments, this check is not reliable and will fail too often. The `identityKey` check does the trick, since PrivateKeys and strings never have this property, while `KeyDeriver`s always do, and those are the only two types to disambiguate.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged