### PR TITLE
Feature/nonce creation with counterparty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.10 - 2025-01-27](#139---2025-01-27)
 - [1.3.9 - 2025-01-23](#139---2025-01-23)
 - [1.3.8 - 2025-01-20](#138---2025-01-20)
 - [1.3.7 - 2025-01-18](#137---2025-01-18)
@@ -75,7 +76,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Security
 
-## [1.3.9] - 2025-01-23
+## [1.3.10] - 2025-01-27
+
+### Changed
+
+- Create and Verify Nonce utility functions now support optional counterparty param.
+- This enables the verification of nonces created by a counterparty.
+
+---
 
 ### Changed
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1129,13 +1129,13 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 ### Function: createNonce
 
-Creates a nonce derived from a privateKey
+Creates a nonce derived from a wallet
 
 ```ts
-export async function createNonce(wallet: WalletInterface): Promise<string> 
+export async function createNonce(wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<string> 
 ```
 
-See also: [WalletInterface](#interface-walletinterface)
+See also: [WalletCounterparty](#type-walletcounterparty), [WalletInterface](#interface-walletinterface)
 
 <details>
 
@@ -1144,6 +1144,11 @@ See also: [WalletInterface](#interface-walletinterface)
 Returns
 
 A random nonce derived with a wallet
+
+Argument Details
+
++ **counterparty**
+  + The counterparty to the nonce creation. Defaults to 'self'.
 
 </details>
 
@@ -1155,10 +1160,10 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 Verifies a nonce derived from a wallet
 
 ```ts
-export async function verifyNonce(nonce: string, wallet: WalletInterface): Promise<boolean> 
+export async function verifyNonce(nonce: string, wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<boolean> 
 ```
 
-See also: [WalletInterface](#interface-walletinterface)
+See also: [WalletCounterparty](#type-walletcounterparty), [WalletInterface](#interface-walletinterface)
 
 <details>
 
@@ -1172,6 +1177,8 @@ Argument Details
 
 + **nonce**
   + A nonce to verify as a base64 string.
++ **counterparty**
+  + The counterparty to the nonce creation. Defaults to 'self'.
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/Peer.ts
+++ b/src/auth/Peer.ts
@@ -39,7 +39,7 @@ export class Peer {
    * @param {SessionManager} [sessionManager] - Optional SessionManager to be used for managing peer sessions.
    * @param {boolean} [autoPersistLastSession] - Whether to auto-persist the session with the last-interacted-with peer. Defaults to true.
    */
-  constructor(
+  constructor (
     wallet: WalletInterface,
     transport: Transport,
     certificatesToRequest?: RequestedCertificateSet,
@@ -66,7 +66,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if the message fails to send.
    */
-  async toPeer(message: number[], identityKey?: string, maxWaitTime?: number): Promise<void> {
+  async toPeer (message: number[], identityKey?: string, maxWaitTime?: number): Promise<void> {
     if (this.autoPersistLastSession && this.lastInteractedWithPeer && typeof identityKey !== 'string') {
       identityKey = this.lastInteractedWithPeer
     }
@@ -111,7 +111,7 @@ export class Peer {
   * @returns {Promise<void>} Resolves if the certificate request message is successfully sent.
   * @throws Will throw an error if the peer session is not authenticated or if sending the request fails.
   */
-  async requestCertificates(certificatesToRequest: RequestedCertificateSet, identityKey?: string, maxWaitTime = 10000): Promise<void> {
+  async requestCertificates (certificatesToRequest: RequestedCertificateSet, identityKey?: string, maxWaitTime = 10000): Promise<void> {
     const peerSession = await this.getAuthenticatedSession(identityKey, maxWaitTime)
 
     // Prepare the general message
@@ -152,7 +152,7 @@ export class Peer {
    * @returns {Promise<PeerSession>} - A promise that resolves with an authenticated `PeerSession`.
    * @throws {Error} - Throws an error if the transport is not connected or if the handshake fails.
    */
-  async getAuthenticatedSession(identityKey?: string, maxWaitTime?: number): Promise<PeerSession> {
+  async getAuthenticatedSession (identityKey?: string, maxWaitTime?: number): Promise<PeerSession> {
     if (!this.transport) {
       throw new Error('Peer transport is not connected!')
     }
@@ -175,7 +175,7 @@ export class Peer {
    * @param {(senderPublicKey: string, payload: number[]) => void} callback - The function to call when a general message is received.
    * @returns {number} The ID of the callback listener.
    */
-  listenForGeneralMessages(callback: (senderPublicKey: string, payload: number[]) => void): number {
+  listenForGeneralMessages (callback: (senderPublicKey: string, payload: number[]) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onGeneralMessageReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -186,7 +186,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the callback to remove.
    */
-  stopListeningForGeneralMessages(callbackID: number): void {
+  stopListeningForGeneralMessages (callbackID: number): void {
     this.onGeneralMessageReceivedCallbacks.delete(callbackID)
   }
 
@@ -196,7 +196,7 @@ export class Peer {
    * @param {(certs: VerifiableCertificate[]) => void} callback - The function to call when certificates are received.
    * @returns {number} The ID of the callback listener.
    */
-  listenForCertificatesReceived(callback: (senderPublicKey: string, certs: VerifiableCertificate[]) => void): number {
+  listenForCertificatesReceived (callback: (senderPublicKey: string, certs: VerifiableCertificate[]) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onCertificatesReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -207,7 +207,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the certificates received callback to cancel.
    */
-  stopListeningForCertificatesReceived(callbackID: number): void {
+  stopListeningForCertificatesReceived (callbackID: number): void {
     this.onCertificatesReceivedCallbacks.delete(callbackID)
   }
 
@@ -217,7 +217,7 @@ export class Peer {
    * @param {(requestedCertificates: RequestedCertificateSet) => void} callback - The function to call when a certificate request is received
    * @returns {number} The ID of the callback listener.
    */
-  listenForCertificatesRequested(callback: (senderPublicKey: string, requestedCertificates: RequestedCertificateSet) => void): number {
+  listenForCertificatesRequested (callback: (senderPublicKey: string, requestedCertificates: RequestedCertificateSet) => void): number {
     const callbackID = this.callbackIdCounter++
     this.onCertificateRequestReceivedCallbacks.set(callbackID, callback)
     return callbackID
@@ -228,7 +228,7 @@ export class Peer {
    *
    * @param {number} callbackID - The ID of the requested certificates callback to cancel.
    */
-  stopListeningForCertificatesRequested(callbackID: number): void {
+  stopListeningForCertificatesRequested (callbackID: number): void {
     this.onCertificateRequestReceivedCallbacks.delete(callbackID)
   }
 
@@ -239,7 +239,7 @@ export class Peer {
    * @param {string} [identityKey] - The identity public key of the peer.
    * @returns {Promise<string>} A promise that resolves to the session nonce.
    */
-  private async initiateHandshake(identityKey?: string, maxWaitTime = 10000): Promise<string> {
+  private async initiateHandshake (identityKey?: string, maxWaitTime = 10000): Promise<string> {
     const sessionNonce = await createNonce(this.wallet) // Initial request nonce
     this.sessionManager.addSession({
       isAuthenticated: false,
@@ -265,7 +265,7 @@ export class Peer {
    * @param {string} sessionNonce - The session nonce created in the initial request.
    * @returns {Promise<string>} A promise that resolves with the session nonce when the initial response is received.
    */
-  private async waitForInitialResponse(sessionNonce: string, maxWaitTime = 10000): Promise<string> {
+  private async waitForInitialResponse (sessionNonce: string, maxWaitTime = 10000): Promise<string> {
     return await new Promise((resolve, reject) => {
       const callbackID = this.listenForInitialResponse(sessionNonce, (sessionNonce) => {
         clearTimeout(timeoutHandle)
@@ -288,7 +288,7 @@ export class Peer {
    * @param {(sessionNonce: string) => void} callback - The callback to invoke when the initial response is received.
    * @returns {number} The ID of the callback listener.
    */
-  private listenForInitialResponse(sessionNonce: string, callback: (sessionNonce: string) => void) {
+  private listenForInitialResponse (sessionNonce: string, callback: (sessionNonce: string) => void) {
     const callbackID = this.callbackIdCounter++
     this.onInitialResponseReceivedCallbacks.set(callbackID, { callback, sessionNonce })
     return callbackID
@@ -300,7 +300,7 @@ export class Peer {
    * @private
    * @param {number} callbackID - The ID of the callback to remove.
    */
-  private stopListeningForInitialResponses(callbackID: number) {
+  private stopListeningForInitialResponses (callbackID: number) {
     this.onInitialResponseReceivedCallbacks.delete(callbackID)
   }
 
@@ -310,7 +310,7 @@ export class Peer {
    * @param {AuthMessage} message - The incoming message to process.
    * @returns {Promise<void>}
    */
-  private async handleIncomingMessage(message: AuthMessage): Promise<void> {
+  private async handleIncomingMessage (message: AuthMessage): Promise<void> {
     if (!message.version || message.version !== AUTH_VERSION) {
       console.error(`Invalid message auth version! Received: ${message.version}, expected: ${AUTH_VERSION}`)
       return
@@ -343,7 +343,7 @@ export class Peer {
    * @param {AuthMessage} message - The incoming initial request message.
    * @returns {Promise<void>}
    */
-  async processInitialRequest(message: AuthMessage) {
+  async processInitialRequest (message: AuthMessage) {
     if (!message.identityKey || !message.initialNonce) {
       throw new Error('Missing required fields in initialResponse message.')
     }
@@ -406,7 +406,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processInitialResponse(message: AuthMessage) {
+  private async processInitialResponse (message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Initial response nonce verification failed from peer: ${message.identityKey}`)
@@ -478,7 +478,7 @@ export class Peer {
    * @param {AuthMessage} message - The certificate request message received from the peer.
    * @throws {Error} Throws an error if nonce verification fails, or the message signature is invalid.
    */
-  private async processCertificateRequest(message: AuthMessage) {
+  private async processCertificateRequest (message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Unable to verify nonce for certificate request message from: ${message.identityKey}`)
@@ -520,7 +520,7 @@ export class Peer {
    *
    * @throws {Error} Throws an error if the peer session could not be authenticated or if message signing fails.
    */
-  async sendCertificateResponse(
+  async sendCertificateResponse (
     verifierIdentityKey: string,
     certificates: VerifiableCertificate[]
   ) {
@@ -559,7 +559,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processCertificateResponse(
+  private async processCertificateResponse (
     message: AuthMessage
   ) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
@@ -597,7 +597,7 @@ export class Peer {
    * @returns {Promise<void>}
    * @throws Will throw an error if nonce verification or signature verification fails.
    */
-  private async processGeneralMessage(message: AuthMessage) {
+  private async processGeneralMessage (message: AuthMessage) {
     const validNonce = await verifyNonce(message.yourNonce, this.wallet)
     if (!validNonce) {
       throw new Error(`Unable to verify nonce for general message from: ${message.identityKey}`)

--- a/src/auth/utils/createNonce.ts
+++ b/src/auth/utils/createNonce.ts
@@ -1,15 +1,21 @@
-import { Utils, Random, WalletInterface } from '../../../mod.js'
+import { Utils, Random, WalletInterface, WalletCounterparty } from '../../../mod.js'
 
 /**
- * Creates a nonce derived from a privateKey
+ * Creates a nonce derived from a wallet
  * @param wallet
+ * @param counterparty - The counterparty to the nonce creation. Defaults to 'self'.
  * @returns A random nonce derived with a wallet
  */
-export async function createNonce(wallet: WalletInterface): Promise<string> {
+export async function createNonce(wallet: WalletInterface, counterparty: WalletCounterparty = 'self'): Promise<string> {
   // Generate 16 random bytes for the first half of the data
   const firstHalf = Random(16)
   // Create an sha256 HMAC
-  const { hmac } = await wallet.createHmac({ protocolID: [2, 'server hmac'], keyID: Utils.toUTF8(firstHalf), data: firstHalf, counterparty: 'self' })
+  const { hmac } = await wallet.createHmac({
+    protocolID: [2, 'server hmac'],
+    keyID: Utils.toUTF8(firstHalf),
+    data: firstHalf,
+    counterparty
+  })
   // Concatenate firstHalf and secondHalf as the nonce bytes
   const nonceBytes = [...firstHalf, ...hmac]
   return Utils.toBase64(nonceBytes)

--- a/src/auth/utils/verifyNonce.ts
+++ b/src/auth/utils/verifyNonce.ts
@@ -1,12 +1,13 @@
-import { Utils, WalletInterface } from '../../../mod.js'
+import { Utils, WalletCounterparty, WalletInterface } from '../../../mod.js'
 
 /**
  * Verifies a nonce derived from a wallet
  * @param nonce - A nonce to verify as a base64 string.
  * @param wallet
+ * @param counterparty - The counterparty to the nonce creation. Defaults to 'self'.
  * @returns The status of the validation
  */
-export async function verifyNonce(nonce: string, wallet: WalletInterface): Promise<boolean> {
+export async function verifyNonce(nonce: string, wallet: WalletInterface, counterparty: WalletCounterparty = 'self'): Promise<boolean> {
   // Convert nonce from base64 string to Uint8Array
   const buffer = Utils.toArray(nonce, 'base64')
 
@@ -20,7 +21,7 @@ export async function verifyNonce(nonce: string, wallet: WalletInterface): Promi
     hmac,
     protocolID: [2, 'server hmac'],
     keyID: Utils.toUTF8(data),
-    counterparty: 'self'
+    counterparty
   })
 
   return valid

--- a/src/overlay-tools/OverlayAdminTokenTemplate.ts
+++ b/src/overlay-tools/OverlayAdminTokenTemplate.ts
@@ -15,7 +15,7 @@ export default class OverlayAdminTokenTemplate implements ScriptTemplate {
      * @param script Locking script comprising a SHIP or SLAP token to decode
      * @returns Decoded SHIP or SLAP advertisement
      */
-  static decode(script: LockingScript): { protocol: 'SHIP' | 'SLAP', identityKey: string, domain: string, topicOrService: string } {
+  static decode (script: LockingScript): { protocol: 'SHIP' | 'SLAP', identityKey: string, domain: string, topicOrService: string } {
     const result = PushDrop.decode(script)
     if (result.fields.length < 4) {
       throw new Error('Invalid SHIP/SLAP advertisement!')
@@ -39,7 +39,7 @@ export default class OverlayAdminTokenTemplate implements ScriptTemplate {
      * Constructs a new Overlay Admin template instance
      * @param wallet Wallet to use for locking and unlocking
      */
-  constructor(wallet: WalletInterface) {
+  constructor (wallet: WalletInterface) {
     this.pushDrop = new PushDrop(wallet)
   }
 
@@ -50,7 +50,7 @@ export default class OverlayAdminTokenTemplate implements ScriptTemplate {
      * @param topicOrService Topic or service to advertise
      * @returns Locking script comprising the advertisement token
      */
-  async lock(protocol: 'SHIP' | 'SLAP', domain: string, topicOrService: string): Promise<LockingScript> {
+  async lock (protocol: 'SHIP' | 'SLAP', domain: string, topicOrService: string): Promise<LockingScript> {
     const { publicKey: identityKey } = await this.pushDrop.wallet.getPublicKey({ identityKey: true })
     return await this.pushDrop.lock(
       [
@@ -70,7 +70,7 @@ export default class OverlayAdminTokenTemplate implements ScriptTemplate {
      * @param protocol SHIP or SLAP, depending on the token to unlock
      * @returns Script unlocker capable of unlocking the advertisement token
      */
-  unlock(protocol: 'SHIP' | 'SLAP'): {
+  unlock (protocol: 'SHIP' | 'SLAP'): {
     sign: (tx: Transaction, inputIndex: number) => Promise<UnlockingScript>
     estimateLength: (tx: Transaction, inputIndex: number) => Promise<number>
   } {

--- a/src/wallet/ProtoWallet.ts
+++ b/src/wallet/ProtoWallet.ts
@@ -35,14 +35,14 @@ import {
 export class ProtoWallet {
   keyDeriver: KeyDeriverApi
 
-  constructor(rootKeyOrKeyDeriver: PrivateKey | 'anyone' | KeyDeriverApi) {
+  constructor (rootKeyOrKeyDeriver: PrivateKey | 'anyone' | KeyDeriverApi) {
     if (typeof (rootKeyOrKeyDeriver as KeyDeriver).identityKey !== 'string') {
       rootKeyOrKeyDeriver = new KeyDeriver(rootKeyOrKeyDeriver as PrivateKey | 'anyone')
     }
     this.keyDeriver = rootKeyOrKeyDeriver as KeyDeriver
   }
 
-  async getPublicKey(
+  async getPublicKey (
     args: GetPublicKeyArgs
   ): Promise<{ publicKey: PubKeyHex }> {
     if (args.identityKey) {
@@ -64,7 +64,7 @@ export class ProtoWallet {
     }
   }
 
-  async revealCounterpartyKeyLinkage(
+  async revealCounterpartyKeyLinkage (
     args: RevealCounterpartyKeyLinkageArgs
   ): Promise<RevealCounterpartyKeyLinkageResult> {
     const { publicKey: identityKey } = await this.getPublicKey({ identityKey: true })
@@ -98,7 +98,7 @@ export class ProtoWallet {
     }
   }
 
-  async revealSpecificKeyLinkage(
+  async revealSpecificKeyLinkage (
     args: RevealSpecificKeyLinkageArgs
   ): Promise<RevealSpecificKeyLinkageResult> {
     const { publicKey: identityKey } = await this.getPublicKey({ identityKey: true })
@@ -131,7 +131,7 @@ export class ProtoWallet {
     }
   }
 
-  async encrypt(
+  async encrypt (
     args: WalletEncryptArgs
   ): Promise<WalletEncryptResult> {
     const key = this.keyDeriver.deriveSymmetricKey(
@@ -142,7 +142,7 @@ export class ProtoWallet {
     return { ciphertext: key.encrypt(args.plaintext) as number[] }
   }
 
-  async decrypt(
+  async decrypt (
     args: WalletDecryptArgs
   ): Promise<WalletDecryptResult> {
     const key = this.keyDeriver.deriveSymmetricKey(
@@ -153,7 +153,7 @@ export class ProtoWallet {
     return { plaintext: key.decrypt(args.ciphertext) as number[] }
   }
 
-  async createHmac(
+  async createHmac (
     args: CreateHmacArgs
   ): Promise<CreateHmacResult> {
     const key = this.keyDeriver.deriveSymmetricKey(
@@ -164,7 +164,7 @@ export class ProtoWallet {
     return { hmac: Hash.sha256hmac(key.toArray(), args.data) }
   }
 
-  async verifyHmac(
+  async verifyHmac (
     args: VerifyHmacArgs
   ): Promise<VerifyHmacResult> {
     const key = this.keyDeriver.deriveSymmetricKey(
@@ -181,7 +181,7 @@ export class ProtoWallet {
     return { valid }
   }
 
-  async createSignature(
+  async createSignature (
     args: CreateSignatureArgs
   ): Promise<CreateSignatureResult> {
     if (!args.hashToDirectlySign && !args.data) {
@@ -196,7 +196,7 @@ export class ProtoWallet {
     return { signature: ECDSA.sign(new BigNumber(hash), key, true).toDER() as number[] }
   }
 
-  async verifySignature(
+  async verifySignature (
     args: VerifySignatureArgs
   ): Promise<VerifySignatureResult> {
     if (!args.hashToDirectlyVerify && !args.data) {

--- a/src/wallet/WalletClient.ts
+++ b/src/wallet/WalletClient.ts
@@ -13,7 +13,7 @@ const MAX_XDM_RESPONSE_WAIT = 200
 export default class WalletClient implements WalletInterface {
   public substrate: 'auto' | WalletInterface
   originator?: OriginatorDomainNameStringUnder250Bytes
-  constructor(substrate: 'auto' | 'Cicada' | 'XDM' | 'window.CWI' | 'json-api' | WalletInterface = 'auto', originator?: OriginatorDomainNameStringUnder250Bytes) {
+  constructor (substrate: 'auto' | 'Cicada' | 'XDM' | 'window.CWI' | 'json-api' | WalletInterface = 'auto', originator?: OriginatorDomainNameStringUnder250Bytes) {
     if (substrate === 'Cicada') substrate = new WalletWireTransceiver(new HTTPWalletWire(originator))
     if (substrate === 'window.CWI') substrate = new WindowCWISubstrate()
     if (substrate === 'XDM') substrate = new XDMSubstrate()
@@ -22,7 +22,7 @@ export default class WalletClient implements WalletInterface {
     this.originator = originator
   }
 
-  async connectToSubstrate() {
+  async connectToSubstrate () {
     if (typeof this.substrate === 'object') {
       return // substrate is already connected
     }
@@ -68,141 +68,141 @@ export default class WalletClient implements WalletInterface {
     }
   }
 
-  async createAction(args: CreateActionArgs): Promise<CreateActionResult> {
+  async createAction (args: CreateActionArgs): Promise<CreateActionResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).createAction(args, this.originator)
   }
 
-  async signAction(args: SignActionArgs): Promise<SignActionResult> {
+  async signAction (args: SignActionArgs): Promise<SignActionResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).signAction(args, this.originator)
   }
 
-  async abortAction(args: { reference: Base64String }): Promise<{ aborted: true }> {
+  async abortAction (args: { reference: Base64String }): Promise<{ aborted: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).abortAction(args, this.originator)
   }
 
-  async listActions(args: ListActionsArgs): Promise<ListActionsResult> {
+  async listActions (args: ListActionsArgs): Promise<ListActionsResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).listActions(args, this.originator)
   }
 
-  async internalizeAction(args: InternalizeActionArgs): Promise<{ accepted: true }> {
+  async internalizeAction (args: InternalizeActionArgs): Promise<{ accepted: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).internalizeAction(args, this.originator)
   }
 
-  async listOutputs(args: ListOutputsArgs): Promise<ListOutputsResult> {
+  async listOutputs (args: ListOutputsArgs): Promise<ListOutputsResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).listOutputs(args, this.originator)
   }
 
-  async relinquishOutput(args: { basket: BasketStringUnder300Bytes, output: OutpointString }): Promise<{ relinquished: true }> {
+  async relinquishOutput (args: { basket: BasketStringUnder300Bytes, output: OutpointString }): Promise<{ relinquished: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).relinquishOutput(args, this.originator)
   }
 
-  async getPublicKey(args: { identityKey?: true, protocolID?: [SecurityLevel, ProtocolString5To400Bytes], keyID?: KeyIDStringUnder800Bytes, privileged?: BooleanDefaultFalse, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', forSelf?: BooleanDefaultFalse }): Promise<{ publicKey: PubKeyHex }> {
+  async getPublicKey (args: { identityKey?: true, protocolID?: [SecurityLevel, ProtocolString5To400Bytes], keyID?: KeyIDStringUnder800Bytes, privileged?: BooleanDefaultFalse, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', forSelf?: BooleanDefaultFalse }): Promise<{ publicKey: PubKeyHex }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).getPublicKey(args, this.originator)
   }
 
-  async revealCounterpartyKeyLinkage(args: { counterparty: PubKeyHex, verifier: PubKeyHex, privilegedReason?: DescriptionString5to50Bytes, privileged?: BooleanDefaultFalse }): Promise<{ prover: PubKeyHex, verifier: PubKeyHex, counterparty: PubKeyHex, revelationTime: ISOTimestampString, encryptedLinkage: Byte[], encryptedLinkageProof: Byte[] }> {
+  async revealCounterpartyKeyLinkage (args: { counterparty: PubKeyHex, verifier: PubKeyHex, privilegedReason?: DescriptionString5to50Bytes, privileged?: BooleanDefaultFalse }): Promise<{ prover: PubKeyHex, verifier: PubKeyHex, counterparty: PubKeyHex, revelationTime: ISOTimestampString, encryptedLinkage: Byte[], encryptedLinkageProof: Byte[] }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).revealCounterpartyKeyLinkage(args, this.originator)
   }
 
-  async revealSpecificKeyLinkage(args: { counterparty: PubKeyHex, verifier: PubKeyHex, protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, privileged?: BooleanDefaultFalse }): Promise<{ prover: PubKeyHex, verifier: PubKeyHex, counterparty: PubKeyHex, protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, encryptedLinkage: Byte[], encryptedLinkageProof: Byte[], proofType: Byte }> {
+  async revealSpecificKeyLinkage (args: { counterparty: PubKeyHex, verifier: PubKeyHex, protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, privileged?: BooleanDefaultFalse }): Promise<{ prover: PubKeyHex, verifier: PubKeyHex, counterparty: PubKeyHex, protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, encryptedLinkage: Byte[], encryptedLinkageProof: Byte[], proofType: Byte }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).revealSpecificKeyLinkage(args, this.originator)
   }
 
-  async encrypt(args: { plaintext: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ ciphertext: Byte[] }> {
+  async encrypt (args: { plaintext: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ ciphertext: Byte[] }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).encrypt(args, this.originator)
   }
 
-  async decrypt(args: { ciphertext: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ plaintext: Byte[] }> {
+  async decrypt (args: { ciphertext: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ plaintext: Byte[] }> {
     return await (this.substrate as WalletInterface).decrypt(args, this.originator)
   }
 
-  async createHmac(args: { data: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ hmac: Byte[] }> {
+  async createHmac (args: { data: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ hmac: Byte[] }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).createHmac(args, this.originator)
   }
 
-  async verifyHmac(args: { data: Byte[], hmac: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ valid: true }> {
+  async verifyHmac (args: { data: Byte[], hmac: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ valid: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).verifyHmac(args, this.originator)
   }
 
-  async createSignature(args: { data?: Byte[], hashToDirectlySign?: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ signature: Byte[] }> {
+  async createSignature (args: { data?: Byte[], hashToDirectlySign?: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', privileged?: BooleanDefaultFalse }): Promise<{ signature: Byte[] }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).createSignature(args, this.originator)
   }
 
-  async verifySignature(args: { data?: Byte[], hashToDirectlyVerify?: Byte[], signature: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', forSelf?: BooleanDefaultFalse, privileged?: BooleanDefaultFalse }): Promise<{ valid: true }> {
+  async verifySignature (args: { data?: Byte[], hashToDirectlyVerify?: Byte[], signature: Byte[], protocolID: [SecurityLevel, ProtocolString5To400Bytes], keyID: KeyIDStringUnder800Bytes, privilegedReason?: DescriptionString5to50Bytes, counterparty?: PubKeyHex | 'self' | 'anyone', forSelf?: BooleanDefaultFalse, privileged?: BooleanDefaultFalse }): Promise<{ valid: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).verifySignature(args, this.originator)
   }
 
-  async acquireCertificate(args: AcquireCertificateArgs): Promise<AcquireCertificateResult> {
+  async acquireCertificate (args: AcquireCertificateArgs): Promise<AcquireCertificateResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).acquireCertificate(args, this.originator)
   }
 
-  async listCertificates(args: { certifiers: PubKeyHex[], types: Base64String[], limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero, privileged?: BooleanDefaultFalse, privilegedReason?: DescriptionString5to50Bytes }): Promise<ListCertificatesResult> {
+  async listCertificates (args: { certifiers: PubKeyHex[], types: Base64String[], limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero, privileged?: BooleanDefaultFalse, privilegedReason?: DescriptionString5to50Bytes }): Promise<ListCertificatesResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).listCertificates(args, this.originator)
   }
 
-  async proveCertificate(args: ProveCertificateArgs): Promise<ProveCertificateResult> {
+  async proveCertificate (args: ProveCertificateArgs): Promise<ProveCertificateResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).proveCertificate(args, this.originator)
   }
 
-  async relinquishCertificate(args: { type: Base64String, serialNumber: Base64String, certifier: PubKeyHex }): Promise<{ relinquished: true }> {
+  async relinquishCertificate (args: { type: Base64String, serialNumber: Base64String, certifier: PubKeyHex }): Promise<{ relinquished: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).relinquishCertificate(args, this.originator)
   }
 
-  async discoverByIdentityKey(args: { identityKey: PubKeyHex, limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero }): Promise<DiscoverCertificatesResult> {
+  async discoverByIdentityKey (args: { identityKey: PubKeyHex, limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero }): Promise<DiscoverCertificatesResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).discoverByIdentityKey(args, this.originator)
   }
 
-  async discoverByAttributes(args: { attributes: Record<CertificateFieldNameUnder50Bytes, string>, limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero }): Promise<DiscoverCertificatesResult> {
+  async discoverByAttributes (args: { attributes: Record<CertificateFieldNameUnder50Bytes, string>, limit?: PositiveIntegerDefault10Max10000, offset?: PositiveIntegerOrZero }): Promise<DiscoverCertificatesResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).discoverByAttributes(args, this.originator)
   }
 
-  async isAuthenticated(args: {} = {}): Promise<AuthenticatedResult> {
+  async isAuthenticated (args: {} = {}): Promise<AuthenticatedResult> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).isAuthenticated(args, this.originator)
   }
 
-  async waitForAuthentication(args: {} = {}): Promise<{ authenticated: true }> {
+  async waitForAuthentication (args: {} = {}): Promise<{ authenticated: true }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).waitForAuthentication(args, this.originator)
   }
 
-  async getHeight(args: {} = {}): Promise<{ height: PositiveInteger }> {
+  async getHeight (args: {} = {}): Promise<{ height: PositiveInteger }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).getHeight(args, this.originator)
   }
 
-  async getHeaderForHeight(args: { height: PositiveInteger }): Promise<{ header: HexString }> {
+  async getHeaderForHeight (args: { height: PositiveInteger }): Promise<{ header: HexString }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).getHeaderForHeight(args, this.originator)
   }
 
-  async getNetwork(args: {} = {}): Promise<{ network: 'mainnet' | 'testnet' }> {
+  async getNetwork (args: {} = {}): Promise<{ network: 'mainnet' | 'testnet' }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).getNetwork(args, this.originator)
   }
 
-  async getVersion(args: {} = {}): Promise<{ version: VersionString7To30Bytes }> {
+  async getVersion (args: {} = {}): Promise<{ version: VersionString7To30Bytes }> {
     await this.connectToSubstrate()
     return await (this.substrate as WalletInterface).getVersion(args, this.originator)
   }


### PR DESCRIPTION
## Description of Changes

- Create and Verify Nonce utility functions now support optional counterparty param.
- This enables the verification of nonces created by a counterparty.

This is particularly useful when creating the SerialNumber for a Certificate.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged