### PR TITLE
Beef clone method now preserves version

### DIFF
--- a/src/transaction/Beef.ts
+++ b/src/transaction/Beef.ts
@@ -627,6 +627,7 @@ export class Beef {
      */
   clone (): Beef {
     const c = new Beef()
+    c.version = this.version
     c.bumps = Array.from(this.bumps)
     c.txs = Array.from(this.txs)
     return c


### PR DESCRIPTION
A one line bug fix. All tests pass. No need to create a new version...

The Beef clone method, used by toBinaryAtomic, failed to preserve version.

When the default version changed from V1 to V2, this broke usting toBinaryAtomic to create a beef for Transaction.fromAtomicBEEF.