### PR TITLE
Whats on chain extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.3.19] - 2025-02-16
+
+### Change
+
+- Make URL, httpClient, getHttpHeaders protected instead of private to support extending WhatsOnChain class.
+
+---
+
 ## [1.3.18] - 2025-02-12
 
 ### Fixed

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -2004,13 +2004,16 @@ Represents a chain tracker based on What's On Chain .
 export default class WhatsOnChain implements ChainTracker {
     readonly network: string;
     readonly apiKey: string;
+    protected readonly URL: string;
+    protected readonly httpClient: HttpClient;
     constructor(network: "main" | "test" | "stn" = "main", config: WhatsOnChainConfig = {}) 
     async isValidRootForHeight(root: string, height: number): Promise<boolean> 
     async currentHeight(): Promise<number> 
+    protected getHttpHeaders(): Record<string, string> 
 }
 ```
 
-See also: [ChainTracker](./transaction.md#interface-chaintracker), [WhatsOnChainConfig](./transaction.md#interface-whatsonchainconfig)
+See also: [ChainTracker](./transaction.md#interface-chaintracker), [HttpClient](./transaction.md#interface-httpclient), [WhatsOnChainConfig](./transaction.md#interface-whatsonchainconfig)
 
 #### Constructor
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.18",
+      "version": "1.3.19",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/transaction/chaintrackers/WhatsOnChain.ts
+++ b/src/transaction/chaintrackers/WhatsOnChain.ts
@@ -21,8 +21,8 @@ interface WhatsOnChainBlockHeader {
 export default class WhatsOnChain implements ChainTracker {
   readonly network: string
   readonly apiKey: string
-  private readonly URL: string
-  private readonly httpClient: HttpClient
+  protected readonly URL: string
+  protected readonly httpClient: HttpClient
 
   /**
    * Constructs an instance of the WhatsOnChain ChainTracker.
@@ -88,7 +88,7 @@ export default class WhatsOnChain implements ChainTracker {
     }
   }
 
-  private getHttpHeaders(): Record<string, string> {
+  protected getHttpHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       Accept: 'application/json'
     }


### PR DESCRIPTION
 Change

- Make URL, httpClient, getHttpHeaders protected instead of private to support extending WhatsOnChain class.

With this change, wallet-toolbox can extend sdk's WhatsOnChain to add support for additional methods, packaged
the way it requires for compatibility with other service providers.