### PR TITLE
[ FIX ] Hash.SHA512._digestHex return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.21 - 2025-02-17](#1321---2025-02-17)
 - [1.3.20- 2025-02-11](#1320---2025-02-17)
 - [1.3.19 - 2025-02-16](#1319---2025-02-16)
 - [1.3.18 - 2025-02-12](#1318---2025-02-12)
@@ -84,6 +85,13 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Security
 
+---
+
+## [1.3.21] - 2025-02-17
+
+### Fixed
+
+- Update type returned in Hash.SHA512._digestHex method so that it doesn't fail tsc builds.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.20",
+      "version": "1.3.21",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/Hash.ts
+++ b/src/primitives/Hash.ts
@@ -1087,7 +1087,7 @@ export class SHA512 extends BaseHash {
     return split32(this.h, 'big')
   }
 
-  _digestHex (): number[] {
+  _digestHex (): string {
     return toHex32(this.h, 'big')
   }
 }


### PR DESCRIPTION
Picked up when running tsc in a project

## Description of Changes

I think this just returns the wrong type. Simple fix.

## Linked Issues / Tickets

```
tsc

node_modules/@bsv/sdk/dist/types/src/primitives/Hash.d.ts:206:5 - error TS2416: Property '_digestHex' in type 'SHA512' is not assignable to the same property in base type 'BaseHash'.
  Type '() => number[]' is not assignable to type '() => string'.
    Type 'number[]' is not assignable to type 'string'.

206     _digestHex(): number[];
```

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged