### PR TITLE
Pushdrop originators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
-- [1.3.23 - 2025-02-19](#1323---2025-02-21)
+- [1.3.24 - 2025-02-22](#1324---2025-02-22)
+- [1.3.23 - 2025-02-21](#1323---2025-02-21)
 - [1.3.22 - 2025-02-19](#1322---2025-02-19)
 - [1.3.21 - 2025-02-17](#1321---2025-02-17)
 - [1.3.20- 2025-02-11](#1320---2025-02-17)
@@ -89,12 +90,21 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.3.24] - 2025-02-22
+
+### Added
+
+- Originator support to PushDrop template
+
+---
+
 ## [1.3.23] - 2025-02-21
 
 ### Fixed
 
 - Fixed a bug with SHIPCast's default configuration.
 
+---
 
 ## [1.3.22] - 2025-02-19
 

--- a/docs/overlay-tools.md
+++ b/docs/overlay-tools.md
@@ -262,7 +262,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 | [HTTPSOverlayLookupFacilitator](#class-httpsoverlaylookupfacilitator) |
 | [LookupResolver](#class-lookupresolver) |
 | [OverlayAdminTokenTemplate](#class-overlayadmintokentemplate) |
-| [SHIPCast](#class-shipcast) |
+| [SHIPBroadcaster](#class-shipbroadcaster) |
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
@@ -430,12 +430,12 @@ Argument Details
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
 ---
-### Class: SHIPCast
+### Class: SHIPBroadcaster
 
 Represents a SHIP transaction broadcaster.
 
 ```ts
-export default class SHIPCast implements Broadcaster {
+export default class SHIPBroadcaster implements Broadcaster {
     constructor(topics: string[], config?: SHIPBroadcasterConfig) 
     async broadcast(tx: Transaction): Promise<BroadcastResponse | BroadcastFailure> 
 }

--- a/docs/script.md
+++ b/docs/script.md
@@ -211,11 +211,12 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 export default class PushDrop implements ScriptTemplate {
     wallet: WalletInterface;
+    originator?: string;
     static decode(script: LockingScript): {
         lockingPublicKey: PublicKey;
         fields: number[][];
     } 
-    constructor(wallet: WalletInterface) 
+    constructor(wallet: WalletInterface, originator?: string) 
     async lock(fields: number[][], protocolID: [
         SecurityLevel,
         string
@@ -237,7 +238,7 @@ See also: [LockingScript](./script.md#class-lockingscript), [PublicKey](./primit
 Constructs a new instance of the PushDrop class.
 
 ```ts
-constructor(wallet: WalletInterface) 
+constructor(wallet: WalletInterface, originator?: string) 
 ```
 See also: [WalletInterface](./wallet.md#interface-walletinterface)
 
@@ -245,6 +246,8 @@ Argument Details
 
 + **wallet**
   + The wallet interface used for creating signatures and accessing public keys.
++ **originator**
+  + — The originator to use with Wallet requests
 
 #### Method decode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.23",
+      "version": "1.3.24",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/script/templates/PushDrop.ts
+++ b/src/script/templates/PushDrop.ts
@@ -57,6 +57,7 @@ const createMinimallyEncodedScriptChunk = (
 
 export default class PushDrop implements ScriptTemplate {
   wallet: WalletInterface
+  originator?: string
 
   /**
    * Decodes a PushDrop script back into its token fields and the locking public key. If a signature was present, it will be the last field returned.
@@ -105,9 +106,11 @@ export default class PushDrop implements ScriptTemplate {
    * Constructs a new instance of the PushDrop class.
    *
    * @param {WalletInterface} wallet - The wallet interface used for creating signatures and accessing public keys.
+   * @param {string} originator — The originator to use with Wallet requests
    */
-  constructor(wallet: WalletInterface) {
+  constructor(wallet: WalletInterface, originator?: string) {
     this.wallet = wallet
+    this.originator = originator
   }
 
   /**
@@ -135,7 +138,7 @@ export default class PushDrop implements ScriptTemplate {
       keyID,
       counterparty,
       forSelf
-    })
+    }, this.originator)
     const lockChunks: Array<{ op: number, data?: number[] }> = []
     const pushDropChunks: Array<{ op: number, data?: number[] }> = []
     lockChunks.push({
@@ -150,7 +153,7 @@ export default class PushDrop implements ScriptTemplate {
         protocolID,
         keyID,
         counterparty
-      })
+      }, this.originator)
       fields.push(signature)
     }
     for (const field of fields) {
@@ -263,7 +266,7 @@ export default class PushDrop implements ScriptTemplate {
           protocolID,
           keyID,
           counterparty
-        })
+        }, this.originator)
         const signature = Signature.fromDER([...bareSignature])
         const txSignature = new TransactionSignature(
           signature.r,


### PR DESCRIPTION
## Description of Changes

PushDrop needs originator support to work with certain protocols in secure admin-only contexts. This is added as an optional second constructor parameter.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] All tests pass locally

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged