### PR TITLE
Fix/utf8 to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.25 - 2025-02-27](#1324---2025-02-27)
 - [1.3.24 - 2025-02-22](#1324---2025-02-22)
 - [1.3.23 - 2025-02-21](#1323---2025-02-21)
 - [1.3.22 - 2025-02-19](#1322---2025-02-19)
@@ -87,6 +88,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.3.25] - 2025-02-27
+
+### Fixed
+
+- Previously, the function split each character’s 16-bit code unit into two bytes (if the high byte was non-zero), which only worked for ASCII and failed on non-ASCII/multi-byte characters. Now emojis can be encoded correctly!
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.24",
+      "version": "1.3.25",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -95,7 +95,7 @@ function utf8ToArray (str: string): number[] {
   const result: number[] = []
 
   for (let i = 0; i < str.length; i++) {
-    let codePoint = str.codePointAt(i)!
+    let codePoint = str.codePointAt(i)
 
     if (codePoint > 0xFFFF) {
       // Valid surrogate pair => skip the next code unit because codePointAt

--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -95,7 +95,12 @@ function utf8ToArray (str: string): number[] {
   const result: number[] = []
 
   for (let i = 0; i < str.length; i++) {
-    let codePoint = str.codePointAt(i)
+    const cp = str.codePointAt(i)
+    if (cp === undefined) {
+      // Should never be out of range.
+      throw new Error(`Index out of range: ${i}`)
+    }
+    let codePoint = cp
 
     if (codePoint > 0xFFFF) {
       // Valid surrogate pair => skip the next code unit because codePointAt

--- a/src/primitives/utils.ts
+++ b/src/primitives/utils.ts
@@ -84,19 +84,56 @@ const base64ToArray = (msg: string): number[] => {
   return result
 }
 
-const utf8ToArray = (msg: string): number[] => {
-  const res: number[] = []
-  for (let i = 0; i < msg.length; i++) {
-    const c = msg.charCodeAt(i)
-    const hi = c >> 8
-    const lo = c & 0xff
-    if (hi !== 0) {
-      res.push(hi, lo)
+/**
+ * Encodes a string into an array of bytes representing its UTF-8 encoding.
+ * Any lone surrogates are replaced with the Unicode replacement character (U+FFFD).
+ *
+ * @param str - The string to encode.
+ * @returns An array of numbers, each representing a byte in the UTF-8 encoded string.
+ */
+function utf8ToArray (str: string): number[] {
+  const result: number[] = []
+
+  for (let i = 0; i < str.length; i++) {
+    let codePoint = str.codePointAt(i)!
+
+    if (codePoint > 0xFFFF) {
+      // Valid surrogate pair => skip the next code unit because codePointAt
+      // has already combined them into a single code point.
+      i++
     } else {
-      res.push(lo)
+      // Check if codePoint is a lone (unpaired) high surrogate or low surrogate.
+      if (codePoint >= 0xD800 && codePoint <= 0xDFFF) {
+        // Replace with the replacement character (U+FFFD).
+        codePoint = 0xFFFD
+      }
+    }
+
+    // Encode according to the UTF-8 standard
+    if (codePoint <= 0x7F) {
+      result.push(codePoint)
+    } else if (codePoint <= 0x7FF) {
+      result.push(
+        0xC0 | (codePoint >> 6),
+        0x80 | (codePoint & 0x3F)
+      )
+    } else if (codePoint <= 0xFFFF) {
+      result.push(
+        0xE0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3F),
+        0x80 | (codePoint & 0x3F)
+      )
+    } else {
+      result.push(
+        0xF0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3F),
+        0x80 | ((codePoint >> 6) & 0x3F),
+        0x80 | (codePoint & 0x3F)
+      )
     }
   }
-  return res
+
+  return result
 }
 
 /**


### PR DESCRIPTION
## Description of Changes

Previously, the Utils.toArray() function for UTF-8 encoding split each character’s 16-bit code unit into two bytes (if the high byte was non-zero), which only worked for ASCII and failed on non-ASCII/multi-byte characters. Now emojis can be encoded correctly!


## Testing Procedure

Tested while linked to auth-express-middleware which sent responses containing emojis.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged