### PR TITLE
Fix/auth fetch payment response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,11 +91,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
-## [1.3.25] - 2025-02-27
+## [1.3.26] - 2025-02-28
 
 ### Fixed
 
-- Previously, the function split each character’s 16-bit code unit into two bytes (if the high byte was non-zero), which only worked for ASCII and failed on non-ASCII/multi-byte characters. Now emojis can be encoded correctly!
+- Fixed a bug with AuthFetch where when responding to error 402, the derivationSuffix was not sent to the server. 
+- Updated used createNonce for the derivationSuffix creation to link it to the sender.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.3.25] - 2025-02-27
+
+### Fixed
+
+- Previously, the function split each character’s 16-bit code unit into two bytes (if the high byte was non-zero), which only worked for ASCII and failed on non-ASCII/multi-byte characters. Now emojis can be encoded correctly!
+
+---
+
 ## [1.3.24] - 2025-02-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.25",
+  "version": "1.3.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.25",
+      "version": "1.3.26",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.25",
+  "version": "1.3.26",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -397,7 +397,7 @@ export class AuthFetch {
     }
 
     // Create a random suffix for the derivation path
-    const derivationSuffix = Utils.toBase64(Random(10))
+    const derivationSuffix = await createNonce(this.wallet)
 
     // Derive the script hex from the server identity key
     const { publicKey: derivedPublicKey } = await this.wallet.getPublicKey({
@@ -421,6 +421,7 @@ export class AuthFetch {
     config.headers = config.headers || {}
     config.headers['x-bsv-payment'] = JSON.stringify({
       derivationPrefix,
+      derivationSuffix,
       transaction: Utils.toBase64(tx)
     })
     config.retryCounter ??= 3

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { Utils, Random, P2PKH, PublicKey, WalletInterface } from '../../../mod.js'
+import { Utils, Random, P2PKH, PublicKey, WalletInterface, createNonce } from '../../../mod.js'
 import { Peer } from '../Peer.js'
 import { SimplifiedFetchTransport } from '../transports/SimplifiedFetchTransport.js'
 import { SessionManager } from '../SessionManager.js'

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -401,11 +401,11 @@ export class AuthFetch {
 
     // Derive the script hex from the server identity key
     const { publicKey: derivedPublicKey } = await this.wallet.getPublicKey({
-      protocolID: [2, 'wallet payment'],
+      protocolID: [2, '3241645161d8'], // wallet payment protocol
       keyID: `${derivationPrefix} ${derivationSuffix}`,
       counterparty: serverIdentityKey
     })
-    const lockingScript = new P2PKH().lock(PublicKey.fromString(derivedPublicKey).toHash()).toHex()
+    const lockingScript = new P2PKH().lock(PublicKey.fromString(derivedPublicKey).toAddress()).toHex()
 
     // Create the payment transaction using createAction
     const { tx } = await this.wallet.createAction({

--- a/src/auth/utils/createNonce.ts
+++ b/src/auth/utils/createNonce.ts
@@ -2,7 +2,8 @@ import {
   Utils,
   Random,
   WalletInterface,
-  WalletCounterparty
+  WalletCounterparty,
+  Base64String
 } from '../../../mod.js'
 
 /**
@@ -14,7 +15,7 @@ import {
 export async function createNonce(
   wallet: WalletInterface,
   counterparty: WalletCounterparty = 'self'
-): Promise<string> {
+): Promise<Base64String> {
   // Generate 16 random bytes for the first half of the data
   const firstHalf = Random(16)
   // Create an sha256 HMAC

--- a/src/auth/utils/verifyNonce.ts
+++ b/src/auth/utils/verifyNonce.ts
@@ -1,4 +1,4 @@
-import { Utils, WalletInterface, WalletCounterparty } from '../../../mod.js'
+import { Utils, WalletInterface, WalletCounterparty, Base64String } from '../../../mod.js'
 
 /**
  * Verifies a nonce derived from a wallet
@@ -8,7 +8,7 @@ import { Utils, WalletInterface, WalletCounterparty } from '../../../mod.js'
  * @returns The status of the validation
  */
 export async function verifyNonce(
-  nonce: string,
+  nonce: Base64String,
   wallet: WalletInterface,
   counterparty: WalletCounterparty = 'self'
 ): Promise<boolean> {


### PR DESCRIPTION
## Description of Changes

- Fixed a bug with AuthFetch where when responding to error 402, the derivationSuffix was not sent to the server. 
- Updated used createNonce for the derivationSuffix creation to link it to the sender.

## Testing Procedure

Bug discovered while testing with real transactions with the payment-express-middleware.

- [] I have added new unit tests
- [x] All tests pass locally
- [] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged