### PR TITLE
Fix/authfetch body defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
-- [1.3.25 - 2025-02-27](#1324---2025-02-27)
+- [1.3.27 - 2025-02-28](#1327---2025-02-28)
+- [1.3.26 - 2025-02-28](#1326---2025-02-28)
+- [1.3.25 - 2025-02-27](#1325---2025-02-27)
 - [1.3.24 - 2025-02-22](#1324---2025-02-22)
 - [1.3.23 - 2025-02-21](#1323---2025-02-21)
 - [1.3.22 - 2025-02-19](#1322---2025-02-19)
@@ -88,6 +90,15 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.3.27] - 2025-02-28
+
+### Fixed
+
+- Added defaults for undefined AuthFetch request body (specifically for content-type of application/json).
+- This prevents signature verification errors due to express defaults for requests with undefined body.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.26",
+      "version": "1.3.27",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
## Description of Changes

- Added defaults for undefined AuthFetch request body (specifically for content-type of application/json).
- This prevents signature verification errors due to express defaults for requests with undefined body.

## Testing Procedure

Tested while linked to the payment-express-middleware repo.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged