### PR TITLE
Fix AuthFetch payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.3.28 - 2025-02-28](#1328---2025-02-28)
 - [1.3.27 - 2025-02-28](#1327---2025-02-28)
 - [1.3.26 - 2025-02-28](#1326---2025-02-28)
 - [1.3.25 - 2025-02-27](#1325---2025-02-27)
@@ -90,6 +91,15 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.3.28] - 2025-02-28
+
+### Fixed
+
+- Persisted payee derivation information in AuthFetch
+- Use the first output index for AuthFetch payments
 
 ---
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1139,10 +1139,10 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 Creates a nonce derived from a wallet
 
 ```ts
-export async function createNonce(wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<string> 
+export async function createNonce(wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<Base64String> 
 ```
 
-See also: [WalletCounterparty](./wallet.md#type-walletcounterparty), [WalletInterface](./wallet.md#interface-walletinterface)
+See also: [Base64String](./wallet.md#type-base64string), [WalletCounterparty](./wallet.md#type-walletcounterparty), [WalletInterface](./wallet.md#interface-walletinterface)
 
 Returns
 
@@ -1161,10 +1161,10 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 Verifies a nonce derived from a wallet
 
 ```ts
-export async function verifyNonce(nonce: string, wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<boolean> 
+export async function verifyNonce(nonce: Base64String, wallet: WalletInterface, counterparty: WalletCounterparty = "self"): Promise<boolean> 
 ```
 
-See also: [WalletCounterparty](./wallet.md#type-walletcounterparty), [WalletInterface](./wallet.md#interface-walletinterface)
+See also: [Base64String](./wallet.md#type-base64string), [WalletCounterparty](./wallet.md#type-walletcounterparty), [WalletInterface](./wallet.md#interface-walletinterface)
 
 Returns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.3.27",
+      "version": "1.3.28",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -405,7 +405,7 @@ export class AuthFetch {
     }
 
     const derivationPrefix = originalResponse.headers.get('x-bsv-payment-derivation-prefix')
-    if (!derivationPrefix) {
+    if (typeof derivationPrefix !== 'string' || derivationPrefix.length < 1) {
       throw new Error('Missing x-bsv-payment-derivation-prefix response header.')
     }
 
@@ -426,8 +426,12 @@ export class AuthFetch {
       outputs: [{
         satoshis: satoshisRequired,
         lockingScript,
+        customInstructions: JSON.stringify({ derivationPrefix, derivationSuffix, payee: serverIdentityKey }),
         outputDescription: 'HTTP request payment'
-      }]
+      }],
+      options: {
+        randomizeOutputs: false
+      }
     })
 
     // Attach the payment to the request headers


### PR DESCRIPTION
## Description of Changes

Use the first output index in AuthFetch for outgoing payments, and persist payee derivation details in custom instructions.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] All tests pass locally

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged