### PR TITLE
fix allowHTTP from false setting in HTTPSOverlayBroadcastFacilitator

### DIFF
--- a/src/overlay-tools/SHIPBroadcaster.ts
+++ b/src/overlay-tools/SHIPBroadcaster.ts
@@ -87,7 +87,7 @@ export class HTTPSOverlayBroadcastFacilitator
 
   constructor(httpClient = fetch, allowHTTP: boolean = false) {
     this.httpClient = httpClient
-    this.allowHTTP = allowHTTP
+    this.allowHTTP = allowHTTP // fix
   }
 
   async send(url: string, taggedBEEF: TaggedBEEF): Promise<STEAK> {

--- a/src/overlay-tools/SHIPBroadcaster.ts
+++ b/src/overlay-tools/SHIPBroadcaster.ts
@@ -67,8 +67,8 @@ export interface SHIPBroadcasterConfig {
   requireAcknowledgmentFromAnyHostForTopics?: 'all' | 'any' | string[]
   /** Determines a mapping whose keys are specific hosts and whose values are the topics (all, any, or a specific list) that must be present within the STEAK received by the given hosts, in order for the broadcast to be considered a success. */
   requireAcknowledgmentFromSpecificHostsForTopics?: Record<
-    string,
-    'all' | 'any' | string[]
+  string,
+  'all' | 'any' | string[]
   >
 }
 
@@ -80,17 +80,16 @@ export interface OverlayBroadcastFacilitator {
 const MAX_SHIP_QUERY_TIMEOUT = 1000
 
 export class HTTPSOverlayBroadcastFacilitator
-  implements OverlayBroadcastFacilitator
-{
+implements OverlayBroadcastFacilitator {
   httpClient: typeof fetch
   allowHTTP: boolean
 
-  constructor(httpClient = fetch, allowHTTP: boolean = false) {
+  constructor (httpClient = fetch, allowHTTP: boolean = false) {
     this.httpClient = httpClient
     this.allowHTTP = allowHTTP // fix
   }
 
-  async send(url: string, taggedBEEF: TaggedBEEF): Promise<STEAK> {
+  async send (url: string, taggedBEEF: TaggedBEEF): Promise<STEAK> {
     if (!url.startsWith('https:') && !this.allowHTTP) {
       throw new Error(
         'HTTPS facilitator can only use URLs that start with "https:"'
@@ -120,17 +119,20 @@ export default class TopicBroadcaster implements Broadcaster {
   private readonly facilitator: OverlayBroadcastFacilitator
   private readonly resolver: LookupResolver
   private readonly requireAcknowledgmentFromAllHostsForTopics:
-    | 'all'
-    | 'any'
-    | string[]
+  | 'all'
+  | 'any'
+  | string[]
+
   private readonly requireAcknowledgmentFromAnyHostForTopics:
-    | 'all'
-    | 'any'
-    | string[]
+  | 'all'
+  | 'any'
+  | string[]
+
   private readonly requireAcknowledgmentFromSpecificHostsForTopics: Record<
-    string,
-    'all' | 'any' | string[]
+  string,
+  'all' | 'any' | string[]
   >
+
   private readonly networkPreset: 'mainnet' | 'testnet' | 'local'
 
   /**
@@ -139,7 +141,7 @@ export default class TopicBroadcaster implements Broadcaster {
    * @param {string[]} topics - The list of SHIP topic names where transactions are to be sent.
    * @param {SHIPBroadcasterConfig} config - Configuration options for the SHIP broadcaster.
    */
-  constructor(topics: string[], config: SHIPBroadcasterConfig = {}) {
+  constructor (topics: string[], config: SHIPBroadcasterConfig = {}) {
     if (topics.length === 0) {
       throw new Error('At least one topic is required for broadcast.')
     }
@@ -171,7 +173,7 @@ export default class TopicBroadcaster implements Broadcaster {
    * @param {Transaction} tx - The transaction to be sent.
    * @returns {Promise<BroadcastResponse | BroadcastFailure>} A promise that resolves to either a success or failure response.
    */
-  async broadcast(
+  async broadcast (
     tx: Transaction
   ): Promise<BroadcastResponse | BroadcastFailure> {
     let beef: number[]
@@ -347,7 +349,7 @@ export default class TopicBroadcaster implements Broadcaster {
     }
   }
 
-  private checkAcknowledgmentFromAllHosts(
+  private checkAcknowledgmentFromAllHosts (
     hostAcknowledgments: Record<string, Set<string>>,
     requiredTopics: string[],
     require: 'all' | 'any'
@@ -375,7 +377,7 @@ export default class TopicBroadcaster implements Broadcaster {
     return true
   }
 
-  private checkAcknowledgmentFromAnyHost(
+  private checkAcknowledgmentFromAnyHost (
     hostAcknowledgments: Record<string, Set<string>>,
     requiredTopics: string[],
     require: 'all' | 'any'
@@ -408,7 +410,7 @@ export default class TopicBroadcaster implements Broadcaster {
     }
   }
 
-  private checkAcknowledgmentFromSpecificHosts(
+  private checkAcknowledgmentFromSpecificHosts (
     hostAcknowledgments: Record<string, Set<string>>,
     requirements: Record<string, 'all' | 'any' | string[]>
   ): boolean {
@@ -460,7 +462,7 @@ export default class TopicBroadcaster implements Broadcaster {
    *
    * @returns A mapping of URLs for hosts interested in this transaction. Keys are URLs, values are which of our topics the specific host cares about.
    */
-  private async findInterestedHosts(): Promise<Record<string, Set<string>>> {
+  private async findInterestedHosts (): Promise<Record<string, Set<string>>> {
     // TODO: cache the list of interested hosts to avoid spamming SHIP trackers.
     // TODO: Monetize the operation of the SHIP tracker system.
     // TODO: Cache ship/slap lookup with expiry (every 5min)


### PR DESCRIPTION
## Description of Changes

fix allowHTTP from false setting in HTTPSOverlayBroadcastFacilitator

## Linked Issues / Tickets

n/a

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [n/a ] I have added new unit tests
- [* ] All tests pass locally
- [n/a ] I have tested manually in my local environment

## Checklist:

- [ *] I have performed a self-review of my own code
- [n/a ] I have made corresponding changes to the documentation
- [n/a ] My changes generate no new warnings
- [ n/a] I have updated `CHANGELOG.md` with my changes
- [ n/a] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ n/a] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [n/a ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged

Ran npm run lint:

![Screenshot from 2025-03-15 20-35-54](https://github.com/user-attachments/assets/ab9e3ec4-0dc1-4c05-aab9-c945579687f6)

