### PR TITLE
Fix SHIP Broadcast Timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.4.8 - 2025-03-17](#148---2025-03-17)
 - [1.4.7 - 2025-03-17](#147---2025-03-17)
 - [1.4.6 - 2025-03-15](#146---2025-03-15)
 - [1.4.5 - 2025-03-15](#145---2025-03-15)
@@ -110,13 +111,21 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.4.8] - 2025-03-17
+
+### Fixed
+
+- Fix timeout in SHIP broadcaster
+
+---
+
 ## [1.4.7] - 2025-03-17
 
 ### Fixed
 
 - Fixed midding headers in StorageUploader
 - Added check for expiryTime in StorageDownloader
-- Fxi timeout in lookup resolver
+- Fix timeout in lookup resolver
 
 ## [1.4.6] - 2025-03-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/overlay-tools/SHIPBroadcaster.ts
+++ b/src/overlay-tools/SHIPBroadcaster.ts
@@ -74,7 +74,7 @@ export interface OverlayBroadcastFacilitator {
   send: (url: string, taggedBEEF: TaggedBEEF) => Promise<STEAK>
 }
 
-const MAX_SHIP_QUERY_TIMEOUT = 1000
+const MAX_SHIP_QUERY_TIMEOUT = 5000
 
 export class HTTPSOverlayBroadcastFacilitator implements OverlayBroadcastFacilitator {
   httpClient: typeof fetch

--- a/src/overlay-tools/__tests/SHIPBroadcaster.test.ts
+++ b/src/overlay-tools/__tests/SHIPBroadcaster.test.ts
@@ -88,7 +88,7 @@ describe('SHIPCast', () => {
           topics: ['tm_foo']
         }
       },
-      1000
+      5000
     )
 
     expect(mockFacilitator.send).toHaveBeenCalledWith('https://shiphost.com', {
@@ -289,7 +289,7 @@ describe('SHIPCast', () => {
           topics: ['tm_foo']
         }
       },
-      1000
+      5000
     )
 
     expect(mockFacilitator.send).not.toHaveBeenCalled()
@@ -516,7 +516,7 @@ describe('SHIPCast', () => {
           topics: ['tm_foo', 'tm_bar']
         }
       },
-      1000
+      5000
     )
 
     expect(mockFacilitator.send).toHaveBeenCalledTimes(2)
@@ -971,7 +971,7 @@ describe('SHIPCast', () => {
           topics: ['tm_foo', 'tm_bar']
         }
       },
-      1000
+      5000
     )
   })
 


### PR DESCRIPTION
## Description of Changes

Extended a SHIP broadcast timeout to accommodate for high latency / mobile internet connections.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged