### PR TITLE
Add action status failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.4.9] - 2025-03-18
+
+### Add
+
+- Add action status 'failed' which is the result of abortAction.
+
+---
+
 ## [1.4.8] - 2025-03-17
 
 ### Fixed

--- a/docs/wallet-substrates.md
+++ b/docs/wallet-substrates.md
@@ -382,7 +382,7 @@ export default class WindowCWISubstrate implements WalletInterface {
         actions: Array<{
             txid: TXIDHexString;
             satoshis: SatoshiValue;
-            status: "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal";
+            status: "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal" | "failed";
             isOutgoing: boolean;
             description: DescriptionString5to50Bytes;
             labels?: LabelStringUnder300Bytes[];

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -2660,7 +2660,7 @@ export default class WindowCWISubstrate implements WalletInterface {
         actions: Array<{
             txid: TXIDHexString;
             satoshis: SatoshiValue;
-            status: "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal";
+            status: "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal" | "failed";
             isOutgoing: boolean;
             description: DescriptionString5to50Bytes;
             labels?: LabelStringUnder300Bytes[];
@@ -3501,7 +3501,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ### Type: ActionStatus
 
 ```ts
-export type ActionStatus = "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal"
+export type ActionStatus = "completed" | "unprocessed" | "sending" | "unproven" | "unsigned" | "nosend" | "nonfinal" | "failed"
 ```
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/wallet/Wallet.interfaces.ts
+++ b/src/wallet/Wallet.interfaces.ts
@@ -230,6 +230,7 @@ export type ActionStatus =
   | 'unsigned'
   | 'nosend'
   | 'nonfinal'
+  | 'failed'
 
 /**
  * Controls behavior of input BEEF validation.

--- a/src/wallet/substrates/WalletWireProcessor.ts
+++ b/src/wallet/substrates/WalletWireProcessor.ts
@@ -626,6 +626,9 @@ export default class WalletWireProcessor implements WalletWire {
               case 'nonfinal':
                 statusCode = 7
                 break
+              case 'failed':
+                statusCode = 8
+                break
               default:
                 statusCode = -1
                 break

--- a/src/wallet/substrates/WalletWireTransceiver.ts
+++ b/src/wallet/substrates/WalletWireTransceiver.ts
@@ -43,7 +43,8 @@ import {
   SignActionResult,
   TXIDHexString,
   VersionString7To30Bytes,
-  WalletInterface
+  WalletInterface,
+  ActionStatus
 } from '../Wallet.interfaces.js'
 import WalletWire from './WalletWire.js'
 import Certificate from '../../auth/certificates/Certificate.js'
@@ -602,14 +603,7 @@ export default class WalletWireTransceiver implements WalletInterface {
     const actions: Array<{
       txid: TXIDHexString
       satoshis: SatoshiValue
-      status:
-      | 'completed'
-      | 'unprocessed'
-      | 'sending'
-      | 'unproven'
-      | 'unsigned'
-      | 'nosend'
-      | 'nonfinal'
+      status: ActionStatus
       isOutgoing: boolean
       description: DescriptionString5to50Bytes
       labels?: LabelStringUnder300Bytes[]
@@ -643,14 +637,7 @@ export default class WalletWireTransceiver implements WalletInterface {
       const satoshis = resultReader.readVarIntNum()
 
       const statusCode = resultReader.readInt8()
-      let status:
-        | 'completed'
-        | 'unprocessed'
-        | 'sending'
-        | 'unproven'
-        | 'unsigned'
-        | 'nosend'
-        | 'nonfinal'
+      let status: ActionStatus
       switch (statusCode) {
         case 1:
           status = 'completed'
@@ -672,6 +659,9 @@ export default class WalletWireTransceiver implements WalletInterface {
           break
         case 7:
           status = 'nonfinal'
+          break
+        case 8:
+          status = 'failed'
           break
         default:
           throw new Error(`Unknown status code: ${statusCode}`)

--- a/src/wallet/substrates/window.CWI.ts
+++ b/src/wallet/substrates/window.CWI.ts
@@ -161,6 +161,7 @@ export default class WindowCWISubstrate implements WalletInterface {
       | 'unsigned'
       | 'nosend'
       | 'nonfinal'
+      | 'failed'
       isOutgoing: boolean
       description: DescriptionString5to50Bytes
       labels?: LabelStringUnder300Bytes[]


### PR DESCRIPTION
Adds action status 'failed' which is the result of abortAction.

Wallet wire updated. This does not alter the bytes, just adds support for a new byte value mapped to 'failed'

All tests pass.

Docs and CHANGELOG updated.