### PR TITLE
Fix/signature verification bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.4.10 - 2025-03-24](#1410---2025-03-24)
 - [1.4.8 - 2025-03-17](#148---2025-03-17)
 - [1.4.7 - 2025-03-17](#147---2025-03-17)
 - [1.4.6 - 2025-03-15](#146---2025-03-15)
@@ -108,6 +109,15 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+
+## [1.4.10] - 2025-03-24
+
+### Fix
+
+- Fix signature pre-image mismatch caused by browser-modified content-type header in AuthFetch.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -355,10 +355,14 @@ export class AuthFetch {
     const includedHeaders: [string, string][] = []
     for (let [k, v] of Object.entries(headers)) {
       k = k.toLowerCase() // We will always sign lower-case header keys
-      if (k.startsWith('x-bsv-') || k === 'content-type' || k === 'authorization') {
+      if (k.startsWith('x-bsv-') || k === 'authorization') {
         if (k.startsWith('x-bsv-auth')) {
           throw new Error('No BSV auth headers allowed here!')
         }
+        includedHeaders.push([k, v])
+      } else if (k.startsWith('content-type')) {
+        // Normalize the Content-Type header by removing any parameters (e.g., "; charset=utf-8")
+        v = (v as string).split(';')[0].trim()
         includedHeaders.push([k, v])
       } else {
         throw new Error('Unsupported header in the simplified fetch implementation. Only content-type, authorization, and x-bsv-* headers are supported.')


### PR DESCRIPTION
## Description of Changes

Added content-type normalization to fix signature pre-image mismatch caused by browser-modified content-type header in AuthFetch.

Chrome automatically appends ; charset=utf-8 to the Content-Type header (application/json becomes application/json; charset=utf-8). This causes signature verification to fail, since the client originally signed application/json.

## Testing Procedure

I have observed the content-type modification while running integration tests with the uhrp-ui and uhrp server.

- [x] I have added new unit tests
- [x] All tests pass locally
- [] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged