### PR TITLE
Ensure consistent ordering of request/response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.4.11 - 2025-03-25](#1411---2025-03-25)
 - [1.4.10 - 2025-03-24](#1410---2025-03-24)
 - [1.4.8 - 2025-03-17](#148---2025-03-17)
 - [1.4.7 - 2025-03-17](#147---2025-03-17)
@@ -112,6 +113,13 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.4.11] - 2025-03-25
+
+### Fix
+
+- Sorts AuthFetch request and response headers by key before serialization to ensure a consistent order for signing and verification.
+
+---
 
 ## [1.4.10] - 2025-03-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/auth/clients/AuthFetch.ts
+++ b/src/auth/clients/AuthFetch.ts
@@ -349,10 +349,11 @@ export class AuthFetch {
     }
 
     // Construct headers to send / sign:
-    // - Custom headers prefixed with x-bsv are included
-    // - x-bsv-auth headers are not allowed
-    // - content-type and authorization are signed by client
-    const includedHeaders: [string, string][] = []
+    // Ensures clients only provided supported HTTP request headers
+    // - Include custom headers prefixed with x-bsv (excluding those starting with x-bsv-auth)
+    // - Include a normalized version of the content-type header
+    // - Include the authorization header
+    const includedHeaders: Array<[string, string]> = []
     for (let [k, v] of Object.entries(headers)) {
       k = k.toLowerCase() // We will always sign lower-case header keys
       if (k.startsWith('x-bsv-') || k === 'authorization') {
@@ -362,12 +363,15 @@ export class AuthFetch {
         includedHeaders.push([k, v])
       } else if (k.startsWith('content-type')) {
         // Normalize the Content-Type header by removing any parameters (e.g., "; charset=utf-8")
-        v = (v as string).split(';')[0].trim()
+        v = v.split(';')[0].trim()
         includedHeaders.push([k, v])
       } else {
         throw new Error('Unsupported header in the simplified fetch implementation. Only content-type, authorization, and x-bsv-* headers are supported.')
       }
     }
+
+    // Sort the headers by key to ensure a consistent order for signing and verification.
+    includedHeaders.sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
 
     // nHeaders
     writer.writeVarIntNum(includedHeaders.length)


### PR DESCRIPTION
## Description of Changes

Sorts AuthFetch request and response headers by key before serialization to ensure a consistent order for signing and verification.

Fixes signature verification errors that were found during integration testing where a bsv-payment was provided in response to a 402 error. The server would try to verify the request signature, but would fail because it was not correctly ordering request headers.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged