### PR TITLE
Fix/registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.4.12 - 2025-03-28](#1412---2025-03-28)
 - [1.4.11 - 2025-03-25](#1411---2025-03-25)
 - [1.4.10 - 2025-03-24](#1410---2025-03-24)
 - [1.4.8 - 2025-03-17](#148---2025-03-17)
@@ -110,6 +111,14 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 
 ### Security
+
+---
+
+## [1.4.12] - 2025-03-28
+
+### Fix
+
+- Removed registryOperator check from token parseLockingScript helper function.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/sdk",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/registry/RegistryClient.ts
+++ b/src/registry/RegistryClient.ts
@@ -199,6 +199,12 @@ export class RegistryClient {
       throw new Error('Invalid registry record. Missing txid, outputIndex, or lockingScript.')
     }
 
+    // Check if the registry record belongs to the current user
+    const currentIdentityKey = (await this.wallet.getPublicKey({ identityKey: true })).publicKey
+    if (registryRecord.registryOperator !== currentIdentityKey) {
+      throw new Error('This registry token does not belong to the current wallet.')
+    }
+
     // Create a descriptive label for the item we’re revoking
     const itemIdentifier =
       registryRecord.definitionType === 'basket'
@@ -419,12 +425,6 @@ export class RegistryClient {
 
       default:
         throw new Error(`Unsupported definition type: ${definitionType as string}`)
-    }
-
-    // Enforce that the pushdrop belongs to the CURRENT identity key
-    const currentIdentityKey = (await this.wallet.getPublicKey({ identityKey: true })).publicKey
-    if (registryOperator !== currentIdentityKey) {
-      throw new Error('This registry token does not belong to the current wallet.')
     }
 
     // Return the typed data plus the operator key


### PR DESCRIPTION
## Description of Changes

Removed registryOperator check from token parseLockingScript helper function.

## Testing Procedure

This was causing resolution to fail in the Metanet Desktop from non registry operators.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged