### PR TITLE
Local k vtweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,18 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [1.4.18] - 2025-04-02
+
+### Changes
+
+- LocalKVStore: Additional testing, passing.
+
+### Added
+
+- WERR_REVIEW_ACTIONS error class and support through HTTPWalletJson
+
+---
+
 ## [1.4.17] - 2025-04-01
 
 ### Added

--- a/docs/kvstore.md
+++ b/docs/kvstore.md
@@ -15,22 +15,13 @@ Allows setting, getting, and removing key-value pairs, with optional encryption.
 ```ts
 export default class LocalKVStore {
     constructor(wallet: WalletInterface = new WalletClient(), context = "kvstore-default", encrypt = true, originator?: string) 
-    getProtocol(key: string): {
-        protocolID: WalletProtocol;
-        keyID: string;
-    } 
-    async getOutputs(key: string, limit?: number): Promise<ListOutputsResult> 
     async get(key: string, defaultValue: string | undefined = undefined): Promise<string | undefined> 
-    getLockingScript(output: WalletOutput, beef: Beef): LockingScript 
-    async lookupValue(key: string, defaultValue: string | undefined, limit?: number): Promise<LookupValueResult> 
-    getInputs(outputs: WalletOutput[]): CreateActionInput[] 
-    async getSpends(key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> 
     async set(key: string, value: string): Promise<OutpointString> 
     async remove(key: string): Promise<string[]> 
 }
 ```
 
-See also: [AtomicBEEF](./wallet.md#type-atomicbeef), [Beef](./transaction.md#class-beef), [CreateActionInput](./wallet.md#interface-createactioninput), [ListOutputsResult](./wallet.md#interface-listoutputsresult), [LockingScript](./script.md#class-lockingscript), [OutpointString](./wallet.md#type-outpointstring), [PushDrop](./script.md#class-pushdrop), [SignActionSpend](./wallet.md#interface-signactionspend), [WalletClient](./wallet.md#class-walletclient), [WalletInterface](./wallet.md#interface-walletinterface), [WalletOutput](./wallet.md#interface-walletoutput), [WalletProtocol](./wallet.md#type-walletprotocol), [encrypt](./messages.md#variable-encrypt)
+See also: [OutpointString](./wallet.md#type-outpointstring), [WalletClient](./wallet.md#class-walletclient), [WalletInterface](./wallet.md#interface-walletinterface), [encrypt](./messages.md#variable-encrypt)
 
 #### Constructor
 

--- a/docs/kvstore.md
+++ b/docs/kvstore.md
@@ -21,7 +21,7 @@ export default class LocalKVStore {
     } 
     async getOutputs(key: string, limit?: number): Promise<ListOutputsResult> 
     async get(key: string, defaultValue: string | undefined = undefined): Promise<string | undefined> 
-    getLockingScriptHex(output: WalletOutput, beef: Beef): LockingScript 
+    getLockingScript(output: WalletOutput, beef: Beef): LockingScript 
     async lookupValue(key: string, defaultValue: string | undefined, limit?: number): Promise<LookupValueResult> 
     getInputs(outputs: WalletOutput[]): CreateActionInput[] 
     async getSpends(key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> 

--- a/docs/kvstore.md
+++ b/docs/kvstore.md
@@ -14,21 +14,30 @@ Allows setting, getting, and removing key-value pairs, with optional encryption.
 
 ```ts
 export default class LocalKVStore {
-    constructor(wallet: WalletInterface = new WalletClient(), context = "kvstore-default", encrypt = true) 
+    constructor(wallet: WalletInterface = new WalletClient(), context = "kvstore-default", encrypt = true, originator?: string) 
+    getProtocol(key: string): {
+        protocolID: WalletProtocol;
+        keyID: string;
+    } 
+    async getOutputs(key: string, limit?: number): Promise<ListOutputsResult> 
     async get(key: string, defaultValue: string | undefined = undefined): Promise<string | undefined> 
+    getLockingScriptHex(output: WalletOutput, beef: Beef): LockingScript 
+    async lookupValue(key: string, defaultValue: string | undefined, limit?: number): Promise<LookupValueResult> 
+    getInputs(outputs: WalletOutput[]): CreateActionInput[] 
+    async getSpends(key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> 
     async set(key: string, value: string): Promise<OutpointString> 
-    async remove(key: string): Promise<OutpointString | undefined> 
+    async remove(key: string): Promise<string[]> 
 }
 ```
 
-See also: [OutpointString](./wallet.md#type-outpointstring), [WalletClient](./wallet.md#class-walletclient), [WalletInterface](./wallet.md#interface-walletinterface), [encrypt](./messages.md#variable-encrypt)
+See also: [AtomicBEEF](./wallet.md#type-atomicbeef), [Beef](./transaction.md#class-beef), [CreateActionInput](./wallet.md#interface-createactioninput), [ListOutputsResult](./wallet.md#interface-listoutputsresult), [LockingScript](./script.md#class-lockingscript), [OutpointString](./wallet.md#type-outpointstring), [PushDrop](./script.md#class-pushdrop), [SignActionSpend](./wallet.md#interface-signactionspend), [WalletClient](./wallet.md#class-walletclient), [WalletInterface](./wallet.md#interface-walletinterface), [WalletOutput](./wallet.md#interface-walletoutput), [WalletProtocol](./wallet.md#type-walletprotocol), [encrypt](./messages.md#variable-encrypt)
 
 #### Constructor
 
 Creates an instance of the localKVStore.
 
 ```ts
-constructor(wallet: WalletInterface = new WalletClient(), context = "kvstore-default", encrypt = true) 
+constructor(wallet: WalletInterface = new WalletClient(), context = "kvstore-default", encrypt = true, originator?: string) 
 ```
 See also: [WalletClient](./wallet.md#class-walletclient), [WalletInterface](./wallet.md#interface-walletinterface), [encrypt](./messages.md#variable-encrypt)
 
@@ -40,6 +49,8 @@ Argument Details
   + The context (basket) for namespacing keys. Defaults to 'kvstore-default'.
 + **encrypt**
   + Whether to encrypt values. Defaults to true.
++ **originator**
+  + — An originator to use with PushDrop and the wallet, if provided.
 
 Throws
 
@@ -67,7 +78,7 @@ Argument Details
 
 Throws
 
-If multiple outputs are found for the key (ambiguous state).
+If too many outputs are found for the key (ambiguous state).
 
 If the found output's locking script cannot be decoded or represents an invalid token format.
 
@@ -80,13 +91,12 @@ If the key does not exist, it does nothing.
 If signing the removal transaction fails, it relinquishes the original outputs instead of spending.
 
 ```ts
-async remove(key: string): Promise<OutpointString | undefined> 
+async remove(key: string): Promise<string[]> 
 ```
-See also: [OutpointString](./wallet.md#type-outpointstring)
 
 Returns
 
-A promise that resolves to the txid of the removal transaction if successful.
+A promise that resolves to the txids of the removal transactions if successful.
 
 Argument Details
 

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -3945,6 +3945,8 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 export type WalletErrorCode = keyof typeof walletErrors
 ```
 
+See also: [walletErrors](./wallet.md#enum-walleterrors)
+
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
 ---
@@ -3973,6 +3975,15 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ---
 ## Enums
 
+| |
+| --- |
+| [SecurityLevels](#enum-securitylevels) |
+| [walletErrors](#enum-walleterrors) |
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
+
+---
+
 ### Enum: SecurityLevels
 
 ```ts
@@ -3984,6 +3995,21 @@ export enum SecurityLevels {
 ```
 
 See also: [Counterparty](./wallet.md#type-counterparty)
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
+
+---
+### Enum: walletErrors
+
+```ts
+export enum walletErrors {
+    unknownError = 1,
+    unsupportedAction = 2,
+    invalidHmac = 3,
+    invalidSignature = 4,
+    reviewActions = 5
+}
+```
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -6,30 +6,31 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 | | | |
 | --- | --- | --- |
-| [AbortActionArgs](#interface-abortactionargs) | [GetVersionResult](#interface-getversionresult) | [SendWithResult](#interface-sendwithresult) |
-| [AbortActionResult](#interface-abortactionresult) | [IdentityCertificate](#interface-identitycertificate) | [SignActionArgs](#interface-signactionargs) |
-| [AcquireCertificateArgs](#interface-acquirecertificateargs) | [IdentityCertifier](#interface-identitycertifier) | [SignActionOptions](#interface-signactionoptions) |
-| [AuthenticatedResult](#interface-authenticatedresult) | [InternalizeActionArgs](#interface-internalizeactionargs) | [SignActionResult](#interface-signactionresult) |
-| [BasketInsertion](#interface-basketinsertion) | [InternalizeActionResult](#interface-internalizeactionresult) | [SignActionSpend](#interface-signactionspend) |
-| [CertificateResult](#interface-certificateresult) | [InternalizeOutput](#interface-internalizeoutput) | [SignableTransaction](#interface-signabletransaction) |
-| [CreateActionArgs](#interface-createactionargs) | [KeyDeriverApi](#interface-keyderiverapi) | [VerifyHmacArgs](#interface-verifyhmacargs) |
-| [CreateActionInput](#interface-createactioninput) | [KeyLinkageResult](#interface-keylinkageresult) | [VerifyHmacResult](#interface-verifyhmacresult) |
-| [CreateActionOptions](#interface-createactionoptions) | [ListActionsArgs](#interface-listactionsargs) | [VerifySignatureArgs](#interface-verifysignatureargs) |
-| [CreateActionOutput](#interface-createactionoutput) | [ListActionsResult](#interface-listactionsresult) | [VerifySignatureResult](#interface-verifysignatureresult) |
-| [CreateActionResult](#interface-createactionresult) | [ListCertificatesArgs](#interface-listcertificatesargs) | [WalletAction](#interface-walletaction) |
-| [CreateHmacArgs](#interface-createhmacargs) | [ListCertificatesResult](#interface-listcertificatesresult) | [WalletActionInput](#interface-walletactioninput) |
-| [CreateHmacResult](#interface-createhmacresult) | [ListOutputsArgs](#interface-listoutputsargs) | [WalletActionOutput](#interface-walletactionoutput) |
-| [CreateSignatureArgs](#interface-createsignatureargs) | [ListOutputsResult](#interface-listoutputsresult) | [WalletCertificate](#interface-walletcertificate) |
-| [CreateSignatureResult](#interface-createsignatureresult) | [ProveCertificateArgs](#interface-provecertificateargs) | [WalletDecryptArgs](#interface-walletdecryptargs) |
-| [DiscoverByAttributesArgs](#interface-discoverbyattributesargs) | [ProveCertificateResult](#interface-provecertificateresult) | [WalletDecryptResult](#interface-walletdecryptresult) |
-| [DiscoverByIdentityKeyArgs](#interface-discoverbyidentitykeyargs) | [RelinquishCertificateArgs](#interface-relinquishcertificateargs) | [WalletEncryptArgs](#interface-walletencryptargs) |
-| [DiscoverCertificatesResult](#interface-discovercertificatesresult) | [RelinquishCertificateResult](#interface-relinquishcertificateresult) | [WalletEncryptResult](#interface-walletencryptresult) |
-| [GetHeaderArgs](#interface-getheaderargs) | [RelinquishOutputArgs](#interface-relinquishoutputargs) | [WalletEncryptionArgs](#interface-walletencryptionargs) |
-| [GetHeaderResult](#interface-getheaderresult) | [RelinquishOutputResult](#interface-relinquishoutputresult) | [WalletErrorObject](#interface-walleterrorobject) |
-| [GetHeightResult](#interface-getheightresult) | [RevealCounterpartyKeyLinkageArgs](#interface-revealcounterpartykeylinkageargs) | [WalletInterface](#interface-walletinterface) |
-| [GetNetworkResult](#interface-getnetworkresult) | [RevealCounterpartyKeyLinkageResult](#interface-revealcounterpartykeylinkageresult) | [WalletOutput](#interface-walletoutput) |
-| [GetPublicKeyArgs](#interface-getpublickeyargs) | [RevealSpecificKeyLinkageArgs](#interface-revealspecifickeylinkageargs) | [WalletPayment](#interface-walletpayment) |
-| [GetPublicKeyResult](#interface-getpublickeyresult) | [RevealSpecificKeyLinkageResult](#interface-revealspecifickeylinkageresult) | [WalletWire](#interface-walletwire) |
+| [AbortActionArgs](#interface-abortactionargs) | [IdentityCertificate](#interface-identitycertificate) | [SignActionArgs](#interface-signactionargs) |
+| [AbortActionResult](#interface-abortactionresult) | [IdentityCertifier](#interface-identitycertifier) | [SignActionOptions](#interface-signactionoptions) |
+| [AcquireCertificateArgs](#interface-acquirecertificateargs) | [InternalizeActionArgs](#interface-internalizeactionargs) | [SignActionResult](#interface-signactionresult) |
+| [AuthenticatedResult](#interface-authenticatedresult) | [InternalizeActionResult](#interface-internalizeactionresult) | [SignActionSpend](#interface-signactionspend) |
+| [BasketInsertion](#interface-basketinsertion) | [InternalizeOutput](#interface-internalizeoutput) | [SignableTransaction](#interface-signabletransaction) |
+| [CertificateResult](#interface-certificateresult) | [KeyDeriverApi](#interface-keyderiverapi) | [VerifyHmacArgs](#interface-verifyhmacargs) |
+| [CreateActionArgs](#interface-createactionargs) | [KeyLinkageResult](#interface-keylinkageresult) | [VerifyHmacResult](#interface-verifyhmacresult) |
+| [CreateActionInput](#interface-createactioninput) | [ListActionsArgs](#interface-listactionsargs) | [VerifySignatureArgs](#interface-verifysignatureargs) |
+| [CreateActionOptions](#interface-createactionoptions) | [ListActionsResult](#interface-listactionsresult) | [VerifySignatureResult](#interface-verifysignatureresult) |
+| [CreateActionOutput](#interface-createactionoutput) | [ListCertificatesArgs](#interface-listcertificatesargs) | [WalletAction](#interface-walletaction) |
+| [CreateActionResult](#interface-createactionresult) | [ListCertificatesResult](#interface-listcertificatesresult) | [WalletActionInput](#interface-walletactioninput) |
+| [CreateHmacArgs](#interface-createhmacargs) | [ListOutputsArgs](#interface-listoutputsargs) | [WalletActionOutput](#interface-walletactionoutput) |
+| [CreateHmacResult](#interface-createhmacresult) | [ListOutputsResult](#interface-listoutputsresult) | [WalletCertificate](#interface-walletcertificate) |
+| [CreateSignatureArgs](#interface-createsignatureargs) | [ProveCertificateArgs](#interface-provecertificateargs) | [WalletDecryptArgs](#interface-walletdecryptargs) |
+| [CreateSignatureResult](#interface-createsignatureresult) | [ProveCertificateResult](#interface-provecertificateresult) | [WalletDecryptResult](#interface-walletdecryptresult) |
+| [DiscoverByAttributesArgs](#interface-discoverbyattributesargs) | [RelinquishCertificateArgs](#interface-relinquishcertificateargs) | [WalletEncryptArgs](#interface-walletencryptargs) |
+| [DiscoverByIdentityKeyArgs](#interface-discoverbyidentitykeyargs) | [RelinquishCertificateResult](#interface-relinquishcertificateresult) | [WalletEncryptResult](#interface-walletencryptresult) |
+| [DiscoverCertificatesResult](#interface-discovercertificatesresult) | [RelinquishOutputArgs](#interface-relinquishoutputargs) | [WalletEncryptionArgs](#interface-walletencryptionargs) |
+| [GetHeaderArgs](#interface-getheaderargs) | [RelinquishOutputResult](#interface-relinquishoutputresult) | [WalletErrorObject](#interface-walleterrorobject) |
+| [GetHeaderResult](#interface-getheaderresult) | [RevealCounterpartyKeyLinkageArgs](#interface-revealcounterpartykeylinkageargs) | [WalletInterface](#interface-walletinterface) |
+| [GetHeightResult](#interface-getheightresult) | [RevealCounterpartyKeyLinkageResult](#interface-revealcounterpartykeylinkageresult) | [WalletOutput](#interface-walletoutput) |
+| [GetNetworkResult](#interface-getnetworkresult) | [RevealSpecificKeyLinkageArgs](#interface-revealspecifickeylinkageargs) | [WalletPayment](#interface-walletpayment) |
+| [GetPublicKeyArgs](#interface-getpublickeyargs) | [RevealSpecificKeyLinkageResult](#interface-revealspecifickeylinkageresult) | [WalletWire](#interface-walletwire) |
+| [GetPublicKeyResult](#interface-getpublickeyresult) | [ReviewActionResult](#interface-reviewactionresult) |  |
+| [GetVersionResult](#interface-getversionresult) | [SendWithResult](#interface-sendwithresult) |  |
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
@@ -837,6 +838,38 @@ See also: [Byte](./wallet.md#type-byte), [KeyIDStringUnder800Bytes](./wallet.md#
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
 ---
+### Interface: ReviewActionResult
+
+```ts
+export interface ReviewActionResult {
+    txid: TXIDHexString;
+    status: ReviewActionResultStatus;
+    competingTxs?: string[];
+    competingBeef?: number[];
+}
+```
+
+See also: [ReviewActionResultStatus](./wallet.md#type-reviewactionresultstatus), [TXIDHexString](./wallet.md#type-txidhexstring)
+
+#### Property competingBeef
+
+Merged beef of competingTxs, valid when status is 'doubleSpend'.
+
+```ts
+competingBeef?: number[]
+```
+
+#### Property competingTxs
+
+Any competing txids reported for this txid, valid when status is 'doubleSpend'.
+
+```ts
+competingTxs?: string[]
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
+
+---
 ### Interface: SendWithResult
 
 ```ts
@@ -1502,6 +1535,7 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 | [HTTPWalletWire](#class-httpwalletwire) |
 | [KeyDeriver](#class-keyderiver) |
 | [ProtoWallet](#class-protowallet) |
+| [WERR_REVIEW_ACTIONS](#class-werr_review_actions) |
 | [WalletClient](#class-walletclient) |
 | [WalletError](#class-walleterror) |
 | [WalletWireProcessor](#class-walletwireprocessor) |
@@ -2095,6 +2129,36 @@ export class ProtoWallet {
 ```
 
 See also: [CreateHmacArgs](./wallet.md#interface-createhmacargs), [CreateHmacResult](./wallet.md#interface-createhmacresult), [CreateSignatureArgs](./wallet.md#interface-createsignatureargs), [CreateSignatureResult](./wallet.md#interface-createsignatureresult), [GetPublicKeyArgs](./wallet.md#interface-getpublickeyargs), [KeyDeriverApi](./wallet.md#interface-keyderiverapi), [PrivateKey](./primitives.md#class-privatekey), [PubKeyHex](./wallet.md#type-pubkeyhex), [RevealCounterpartyKeyLinkageArgs](./wallet.md#interface-revealcounterpartykeylinkageargs), [RevealCounterpartyKeyLinkageResult](./wallet.md#interface-revealcounterpartykeylinkageresult), [RevealSpecificKeyLinkageArgs](./wallet.md#interface-revealspecifickeylinkageargs), [RevealSpecificKeyLinkageResult](./wallet.md#interface-revealspecifickeylinkageresult), [VerifyHmacArgs](./wallet.md#interface-verifyhmacargs), [VerifyHmacResult](./wallet.md#interface-verifyhmacresult), [VerifySignatureArgs](./wallet.md#interface-verifysignatureargs), [VerifySignatureResult](./wallet.md#interface-verifysignatureresult), [WalletDecryptArgs](./wallet.md#interface-walletdecryptargs), [WalletDecryptResult](./wallet.md#interface-walletdecryptresult), [WalletEncryptArgs](./wallet.md#interface-walletencryptargs), [WalletEncryptResult](./wallet.md#interface-walletencryptresult), [decrypt](./messages.md#variable-decrypt), [encrypt](./messages.md#variable-encrypt)
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
+
+---
+### Class: WERR_REVIEW_ACTIONS
+
+When a `createAction` or `signAction` is completed in undelayed mode (`acceptDelayedBroadcast`: false),
+any unsucccessful result will return the results by way of this exception to ensure attention is
+paid to processing errors.
+
+```ts
+export class WERR_REVIEW_ACTIONS extends Error {
+    code: number;
+    isError: boolean = true;
+    constructor(public reviewActionResults: ReviewActionResult[], public sendWithResults: SendWithResult[], public txid?: TXIDHexString, public tx?: AtomicBEEF, public noSendChange?: OutpointString[]) 
+}
+```
+
+See also: [AtomicBEEF](./wallet.md#type-atomicbeef), [OutpointString](./wallet.md#type-outpointstring), [ReviewActionResult](./wallet.md#interface-reviewactionresult), [SendWithResult](./wallet.md#interface-sendwithresult), [TXIDHexString](./wallet.md#type-txidhexstring)
+
+#### Constructor
+
+All parameters correspond to their comparable `createAction` or `signSction` results
+with the exception of `reviewActionResults`;
+which contains more details, particularly for double spend results.
+
+```ts
+constructor(public reviewActionResults: ReviewActionResult[], public sendWithResults: SendWithResult[], public txid?: TXIDHexString, public tx?: AtomicBEEF, public noSendChange?: OutpointString[]) 
+```
+See also: [AtomicBEEF](./wallet.md#type-atomicbeef), [OutpointString](./wallet.md#type-outpointstring), [ReviewActionResult](./wallet.md#interface-reviewactionresult), [SendWithResult](./wallet.md#interface-sendwithresult), [TXIDHexString](./wallet.md#type-txidhexstring)
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
@@ -3459,20 +3523,21 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 | | | |
 | --- | --- | --- |
-| [AcquireCertificateResult](#type-acquirecertificateresult) | [EntityIconURLStringMax500Bytes](#type-entityiconurlstringmax500bytes) | [PositiveIntegerMax10](#type-positiveintegermax10) |
-| [AcquisitionProtocol](#type-acquisitionprotocol) | [EntityNameStringMax100Bytes](#type-entitynamestringmax100bytes) | [PositiveIntegerOrZero](#type-positiveintegerorzero) |
-| [ActionStatus](#type-actionstatus) | [ErrorCodeString10To40Bytes](#type-errorcodestring10to40bytes) | [ProtocolString5To400Bytes](#type-protocolstring5to400bytes) |
-| [AtomicBEEF](#type-atomicbeef) | [ErrorDescriptionString20To200Bytes](#type-errordescriptionstring20to200bytes) | [PubKeyHex](#type-pubkeyhex) |
-| [BEEF](#type-beef) | [HexString](#type-hexstring) | [SatoshiValue](#type-satoshivalue) |
-| [Base64String](#type-base64string) | [ISOTimestampString](#type-isotimestampstring) | [SecurityLevel](#type-securitylevel) |
-| [BasketStringUnder300Bytes](#type-basketstringunder300bytes) | [KeyIDStringUnder800Bytes](#type-keyidstringunder800bytes) | [SendWithResultStatus](#type-sendwithresultstatus) |
-| [BooleanDefaultFalse](#type-booleandefaultfalse) | [KeyringRevealer](#type-keyringrevealer) | [TXIDHexString](#type-txidhexstring) |
-| [BooleanDefaultTrue](#type-booleandefaulttrue) | [LabelStringUnder300Bytes](#type-labelstringunder300bytes) | [TrustSelf](#type-trustself) |
-| [Byte](#type-byte) | [OriginatorDomainNameStringUnder250Bytes](#type-originatordomainnamestringunder250bytes) | [VersionString7To30Bytes](#type-versionstring7to30bytes) |
-| [CallType](#type-calltype) | [OutpointString](#type-outpointstring) | [WalletCounterparty](#type-walletcounterparty) |
-| [CertificateFieldNameUnder50Bytes](#type-certificatefieldnameunder50bytes) | [OutputTagStringUnder300Bytes](#type-outputtagstringunder300bytes) | [WalletErrorCode](#type-walleterrorcode) |
-| [Counterparty](#type-counterparty) | [PositiveInteger](#type-positiveinteger) | [WalletNetwork](#type-walletnetwork) |
-| [DescriptionString5to50Bytes](#type-descriptionstring5to50bytes) | [PositiveIntegerDefault10Max10000](#type-positiveintegerdefault10max10000) | [WalletProtocol](#type-walletprotocol) |
+| [AcquireCertificateResult](#type-acquirecertificateresult) | [EntityNameStringMax100Bytes](#type-entitynamestringmax100bytes) | [ProtocolString5To400Bytes](#type-protocolstring5to400bytes) |
+| [AcquisitionProtocol](#type-acquisitionprotocol) | [ErrorCodeString10To40Bytes](#type-errorcodestring10to40bytes) | [PubKeyHex](#type-pubkeyhex) |
+| [ActionStatus](#type-actionstatus) | [ErrorDescriptionString20To200Bytes](#type-errordescriptionstring20to200bytes) | [ReviewActionResultStatus](#type-reviewactionresultstatus) |
+| [AtomicBEEF](#type-atomicbeef) | [HexString](#type-hexstring) | [SatoshiValue](#type-satoshivalue) |
+| [BEEF](#type-beef) | [ISOTimestampString](#type-isotimestampstring) | [SecurityLevel](#type-securitylevel) |
+| [Base64String](#type-base64string) | [KeyIDStringUnder800Bytes](#type-keyidstringunder800bytes) | [SendWithResultStatus](#type-sendwithresultstatus) |
+| [BasketStringUnder300Bytes](#type-basketstringunder300bytes) | [KeyringRevealer](#type-keyringrevealer) | [TXIDHexString](#type-txidhexstring) |
+| [BooleanDefaultFalse](#type-booleandefaultfalse) | [LabelStringUnder300Bytes](#type-labelstringunder300bytes) | [TrustSelf](#type-trustself) |
+| [BooleanDefaultTrue](#type-booleandefaulttrue) | [OriginatorDomainNameStringUnder250Bytes](#type-originatordomainnamestringunder250bytes) | [VersionString7To30Bytes](#type-versionstring7to30bytes) |
+| [Byte](#type-byte) | [OutpointString](#type-outpointstring) | [WalletCounterparty](#type-walletcounterparty) |
+| [CallType](#type-calltype) | [OutputTagStringUnder300Bytes](#type-outputtagstringunder300bytes) | [WalletErrorCode](#type-walleterrorcode) |
+| [CertificateFieldNameUnder50Bytes](#type-certificatefieldnameunder50bytes) | [PositiveInteger](#type-positiveinteger) | [WalletNetwork](#type-walletnetwork) |
+| [Counterparty](#type-counterparty) | [PositiveIntegerDefault10Max10000](#type-positiveintegerdefault10max10000) | [WalletProtocol](#type-walletprotocol) |
+| [DescriptionString5to50Bytes](#type-descriptionstring5to50bytes) | [PositiveIntegerMax10](#type-positiveintegermax10) |  |
+| [EntityIconURLStringMax500Bytes](#type-entityiconurlstringmax500bytes) | [PositiveIntegerOrZero](#type-positiveintegerorzero) |  |
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 
@@ -3774,6 +3839,23 @@ export type PubKeyHex = HexString
 ```
 
 See also: [HexString](./wallet.md#type-hexstring)
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
+
+---
+### Type: ReviewActionResultStatus
+
+Indicates status of a new Action following a `createAction` or `signAction` in immediate mode:
+When `acceptDelayedBroadcast` is falses.
+
+'success': The action has been broadcast and accepted by the bitcoin processing network.
+'doulbeSpend': The action has been confirmed to double spend one or more inputs, and by the "first-seen-rule" is the loosing transaction.
+'invalidTx': The action was rejected by the processing network as an invalid bitcoin transaction.
+'serviceError': The broadcast services are currently unable to reach the bitcoin network. The action is now queued for delayed retries.
+
+```ts
+export type ReviewActionResultStatus = "success" | "doubleSpend" | "serviceError" | "invalidTx"
+```
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types), [Enums](#enums), [Variables](#variables)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,21 @@
       "version": "1.4.17",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
+<<<<<<< HEAD
         "@eslint/js": "^9.23.0",
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.14",
         "eslint": "^9.23.0",
         "globals": "^16.0.0",
+=======
+        "@eslint/js": "^9.19.0",
+        "@jest/globals": "^29.7.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.13.14",
+        "eslint": "^8.57.1",
+        "globals": "^15.14.0",
+>>>>>>> WERR_REVIEW_ACTIONS
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.3.1",
@@ -1493,9 +1502,15 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
+<<<<<<< HEAD
       "version": "22.13.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+=======
+      "version": "22.13.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.17.tgz",
+      "integrity": "sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==",
+>>>>>>> WERR_REVIEW_ACTIONS
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/sdk",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "type": "module",
   "description": "BSV Blockchain Software Development Kit",
   "main": "dist/cjs/mod.js",

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -94,7 +94,7 @@ export default class LocalKVStore {
 
   getLockingScript (output: WalletOutput, beef: Beef): LockingScript {
     const [txid, vout] = output.outpoint.split('.')
-    const tx = beef.findTxid(txid).tx
+    const tx = beef.findTxid(txid)?.tx
     if (tx == null) { throw new Error(`beef must contain txid ${txid}`) }
     const lockingScript = tx.outputs[Number(vout)].lockingScript
     return lockingScript

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -92,9 +92,9 @@ export default class LocalKVStore {
     return r.value
   }
 
-  getLockingScriptHex (output: WalletOutput, beef: Beef): LockingScript {
+  getLockingScript (output: WalletOutput, beef: Beef): LockingScript {
     const [txid, vout] = output.outpoint.split('.')
-    const tx = beef.findAtomicTransaction(txid)
+    const tx = beef.findTxid(txid).tx
     if (tx == null) { throw new Error(`beef must contain txid ${txid}`) }
     const lockingScript = tx.outputs[Number(vout)].lockingScript
     return lockingScript
@@ -112,7 +112,7 @@ export default class LocalKVStore {
     let field: number[]
     try {
       if (lor.BEEF === undefined) { throw new Error('entire transactions listOutputs option must return valid BEEF') }
-      const lockingScript = this.getLockingScriptHex(output, Beef.fromBinary(lor.BEEF))
+      const lockingScript = this.getLockingScript(output, Beef.fromBinary(lor.BEEF))
       const decoded = PushDrop.decode(lockingScript)
       if (decoded.fields.length < 1 || decoded.fields.length > 2) {
         throw new Error('Invalid token.')

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -95,8 +95,7 @@ export default class LocalKVStore {
   getLockingScriptHex (output: WalletOutput, beef: Beef): LockingScript {
     const [txid, vout] = output.outpoint.split('.')
     const tx = beef.findAtomicTransaction(txid)
-    if (!tx)
-      throw new Error(`beef must contain txid ${txid}`)
+    if (tx == null) { throw new Error(`beef must contain txid ${txid}`) }
     const lockingScript = tx.outputs[Number(vout)].lockingScript
     return lockingScript
   }
@@ -176,8 +175,7 @@ export default class LocalKVStore {
   async set (key: string, value: string): Promise<OutpointString> {
     const current = await this.lookupValue(key, undefined, 10)
     if (current.value === value) {
-      if (current.outpoint === undefined)
-        throw new Error('outpoint must be valid when value is valid and unchanged')
+      if (current.outpoint === undefined) { throw new Error('outpoint must be valid when value is valid and unchanged') }
       // Don't create a new transaction if the value doesn't need to change...
       return current.outpoint
     }
@@ -270,8 +268,7 @@ export default class LocalKVStore {
             reference: signableTransaction.reference,
             spends
           })
-          if (txid === undefined)
-            throw new Error('signAction must return a valid txid')
+          if (txid === undefined) { throw new Error('signAction must return a valid txid') }
           txids.push(txid)
         } catch (_) {
           throw new Error(`There are ${totalOutputs} outputs with tag ${key} that cannot be unlocked.`)

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -42,14 +42,14 @@ export default class LocalKVStore {
    * Creates an instance of the localKVStore.
    *
    * @param {WalletInterface} [wallet=new WalletClient()] - The wallet interface to use. Defaults to a new WalletClient instance.
-   * @param {string} [context='kvstore-default'] - The context (basket) for namespacing keys. Defaults to 'kvstore-default'.
+   * @param {string} [context='kvstoredefault'] - The context (basket) for namespacing keys. Defaults to 'kvstore-default'.
    * @param {boolean} [encrypt=true] - Whether to encrypt values. Defaults to true.
    * @param {string} [originator] — An originator to use with PushDrop and the wallet, if provided.
    * @throws {Error} If the context is missing or empty.
    */
   constructor (
     wallet: WalletInterface = new WalletClient(),
-    context = 'kvstore-default',
+    context = 'kvstoredefault',
     encrypt = true,
     originator?: string
   ) {

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -1,9 +1,10 @@
 import LockingScript from '../script/LockingScript.js'
 import PushDrop from '../script/templates/PushDrop.js'
 import * as Utils from '../primitives/utils.js'
-import { WalletInterface, OutpointString, CreateActionInput, SignActionSpend } from '../wallet/Wallet.interfaces.js'
+import { WalletInterface, OutpointString, CreateActionInput, SignActionSpend, WalletProtocol, ListOutputsResult, WalletOutput, AtomicBEEF } from '../wallet/Wallet.interfaces.js'
 import WalletClient from '../wallet/WalletClient.js'
 import Transaction from '../transaction/Transaction.js'
+import { Beef } from '../transaction/Beef.js'
 
 /**
  * Implements a key-value storage system backed by transaction outputs managed by a wallet.
@@ -61,6 +62,21 @@ export default class LocalKVStore {
     this.originator = originator
   }
 
+  getProtocol(key: string) : { protocolID: WalletProtocol, keyID: string } {
+    return { protocolID: [2, this.context], keyID: key }
+  }
+
+  async getOutputs(key: string, limit?: number) : Promise<ListOutputsResult> {
+    const results = await this.wallet.listOutputs({
+      basket: this.context,
+      tags: [key],
+      tagQueryMode: 'all',
+      include: 'entire transactions',
+      limit
+    })
+    return results
+  }
+
   /**
    * Retrieves the value associated with a given key.
    *
@@ -68,43 +84,79 @@ export default class LocalKVStore {
    * @param {string | undefined} [defaultValue=undefined] - The value to return if the key is not found.
    * @returns {Promise<string | undefined>} A promise that resolves to the value as a string,
    *   the defaultValue if the key is not found, or undefined if no defaultValue is provided.
-   * @throws {Error} If multiple outputs are found for the key (ambiguous state).
+   * @throws {Error} If too many outputs are found for the key (ambiguous state).
    * @throws {Error} If the found output's locking script cannot be decoded or represents an invalid token format.
    */
   async get (key: string, defaultValue: string | undefined = undefined): Promise<string | undefined> {
-    const results = await this.wallet.listOutputs({
-      basket: this.context,
-      tags: [key],
-      include: 'locking scripts'
-    })
-    if (results.outputs.length === 0) {
-      return defaultValue
-    } else if (results.outputs.length > 1) {
-      throw new Error('Multiple tokens found for this key. You need to call set to collapse this ambiguous state before you can get this value again.')
+    const r = await this.lookupValue(key, defaultValue, 5)
+    return r.value
+  }
+
+  getLockingScriptHex(output: WalletOutput, beef: Beef) : LockingScript {
+    const [txid,vout] = output.outpoint.split('.')
+    const tx = beef.findAtomicTransaction(txid)
+    const lockingScript = tx.outputs[Number(vout)].lockingScript
+    return lockingScript
+  }
+
+  async lookupValue(key, defaultValue = undefined, limit?: number)
+  : Promise<{ value: string | undefined, outpoint: OutpointString | undefined, lor: ListOutputsResult }>
+  {
+    const lor = await this.getOutputs(key, limit)
+    const r = { value: defaultValue, outpoint: <OutpointString | undefined>undefined, lor }
+    const { outputs } = lor
+    if (outputs.length === 0) {
+      return r
     }
-    let fields: number[][]
+    const output = outputs.slice(-1)[0]
+    r.outpoint = output.outpoint
+    let field: number[]
     try {
-      if (typeof results.outputs[0].lockingScript !== 'string') {
-        throw new Error('No locking script')
-      }
-      const decoded = PushDrop.decode(LockingScript.fromHex(results.outputs[0].lockingScript))
-      if (decoded.fields.length !== 1) {
+      const lockingScript = this.getLockingScriptHex(output, Beef.fromBinary(lor.BEEF!))
+      const decoded = PushDrop.decode(lockingScript)
+      if (decoded.fields.length < 1 || decoded.fields.length > 2) {
         throw new Error('Invalid token.')
       }
-      fields = decoded.fields
+      field = decoded.fields[0]
     } catch (_) {
-      throw new Error(`Invalid value found. You need to call set to collapse the corrupted state (or relinquish the corrupted ${results.outputs[0].outpoint} output from the ${this.context} basket) before you can get this value again.`)
+      throw new Error(`Invalid value found. You need to call set to collapse the corrupted state (or relinquish the corrupted ${outputs[0].outpoint} output from the ${this.context} basket) before you can get this value again.`)
     }
     if (!this.encrypt) {
-      return Utils.toUTF8(fields[0])
+      r.value = Utils.toUTF8(field)
     } else {
       const { plaintext } = await this.wallet.decrypt({
-        protocolID: [2, this.context],
-        keyID: key,
-        ciphertext: fields[0]
+        ...this.getProtocol(key),
+        ciphertext: field
       })
-      return Utils.toUTF8(plaintext)
+      r.value = Utils.toUTF8(plaintext)
     }
+    return r
+  }
+
+  getInputs(outputs: WalletOutput[]): CreateActionInput[] {
+    const inputs: CreateActionInput[] = []
+    for (let i = 0; i < outputs.length; i++) {
+      inputs.push({
+        outpoint: outputs[i].outpoint,
+        unlockingScriptLength: 74,
+        inputDescription: 'Previous key-value token'
+      })
+    }
+    return inputs
+  }
+
+  async getSpends(key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> {
+    const p = this.getProtocol(key)
+    const tx = Transaction.fromAtomicBEEF(atomicBEEF)
+    const spends: Record<number, SignActionSpend> = {}
+    for (let i = 0; i < outputs.length; i++) {
+      const unlocker = pushdrop.unlock(p.protocolID, p.keyID, 'self')
+      const unlockingScript = await unlocker.sign(tx, i)
+      spends[i] = {
+        unlockingScript: unlockingScript.toHex()
+      }
+    }
+    return spends
   }
 
   /**
@@ -120,96 +172,65 @@ export default class LocalKVStore {
    * @param {string} value - The value to associate with the key.
    * @returns {Promise<OutpointString>} A promise that resolves to the outpoint string (txid.vout) of the new or updated token output.
    */
-  async set (key: string, value: string): Promise<OutpointString> {
+  async set(key: string, value: string): Promise<OutpointString> {
+    const current = await this.lookupValue(key, undefined, 10)
+    if (current.value === value) {
+      // Don't create a new transaction if the value doesn't need to change...
+      return current.outpoint
+    }
+    const protocol = this.getProtocol(key)
     let valueAsArray = Utils.toArray(value, 'utf8')
     if (this.encrypt) {
       const { ciphertext } = await this.wallet.encrypt({
+        ...protocol,
         plaintext: valueAsArray,
-        protocolID: [2, this.context],
-        keyID: key
       })
       valueAsArray = ciphertext
     }
     const pushdrop = new PushDrop(this.wallet, this.originator)
     const lockingScript = await pushdrop.lock(
       [valueAsArray],
-      [2, this.context],
-      key,
+      protocol.protocolID,
+      protocol.keyID,
       'self'
     )
-    const results = await this.wallet.listOutputs({
-      basket: this.context,
-      tags: [key],
-      include: 'entire transactions'
-    })
-    if (results.totalOutputs !== 0) {
-      try {
-        const inputs: CreateActionInput[] = []
-        for (let i = 0; i < results.outputs.length; i++) {
-          inputs.push({
-            outpoint: results.outputs[i].outpoint,
-            unlockingScriptLength: 74,
-            inputDescription: 'Previous key-value token'
-          })
+    const { outputs, BEEF: inputBEEF } = current.lor
+    let outpoint: OutpointString
+    try {
+      const inputs = this.getInputs(outputs)
+      const { txid, signableTransaction } = await this.wallet.createAction({
+        description: `Update ${key} in ${this.context}`,
+        inputBEEF,
+        inputs,
+        outputs: [{
+          basket: this.context,
+          tags: [key],
+          lockingScript: lockingScript.toHex(),
+          satoshis: 1,
+          outputDescription: 'Key-value token'
+        }],
+        options: {
+          acceptDelayedBroadcast: false,
+          randomizeOutputs: false
         }
-        const { signableTransaction } = await this.wallet.createAction({
-          description: `Update ${key} in ${this.context}`,
-          inputBEEF: results.BEEF,
-          inputs,
-          outputs: [{
-            lockingScript: lockingScript.toHex(),
-            satoshis: 1,
-            outputDescription: 'Key-value token'
-          }],
-          options: {
-            acceptDelayedBroadcast: false,
-            randomizeOutputs: false
-          }
-        })
-        if (typeof signableTransaction !== 'object') {
-          throw new Error('Wallet did not return a signable transaction when expected.')
-        }
-        const tx = Transaction.fromAtomicBEEF(signableTransaction.tx)
-        const spends: Record<number, SignActionSpend> = {}
-        for (let i = 0; i < results.outputs.length; i++) {
-          const unlocker = pushdrop.unlock(
-            [2, this.context],
-            key,
-            'self'
-          )
-          const unlockingScript = await unlocker.sign(tx, i)
-          spends[i] = {
-            unlockingScript: unlockingScript.toHex()
-          }
-        }
+      })
+      if (outputs.length > 0 && typeof signableTransaction !== 'object') {
+        throw new Error('Wallet did not return a signable transaction when expected.')
+      }
+      if (txid && !signableTransaction) {
+        outpoint = `${txid}.0`
+      } else {
+        const spends = await this.getSpends(key, outputs, pushdrop, signableTransaction.tx)
         const { txid } = await this.wallet.signAction({
           reference: signableTransaction.reference,
           spends
         })
-        return `${txid as string}.0`
-      } catch (_) {
-        // Signing failed, relinquish original outputs
-        for (let i = 0; i < results.outputs.length; i++) {
-          await this.wallet.relinquishOutput({
-            output: results.outputs[i].outpoint,
-            basket: this.context
-          })
-        }
+        outpoint = `${txid}.0`
       }
+    } catch (_) {
+      throw new Error(`There are ${outputs.length} outputs with tag ${key} that cannot be unlocked.`)
     }
-    const { txid } = await this.wallet.createAction({
-      description: `Set ${key} in ${this.context}`,
-      outputs: [{
-        lockingScript: lockingScript.toHex(),
-        satoshis: 1,
-        outputDescription: 'Key-value token'
-      }],
-      options: {
-        acceptDelayedBroadcast: false,
-        randomizeOutputs: false
-      }
-    })
-    return `${txid as string}.0`
+    return outpoint
   }
 
   /**
@@ -220,63 +241,40 @@ export default class LocalKVStore {
    * If signing the removal transaction fails, it relinquishes the original outputs instead of spending.
    *
    * @param {string} key - The key to remove.
-   * @returns {Promise<string | void>} A promise that resolves to the txid of the removal transaction if successful.
+   * @returns {Promise<string[]>} A promise that resolves to the txids of the removal transactions if successful.
    */
-  async remove (key: string): Promise<OutpointString | undefined> {
-    const results = await this.wallet.listOutputs({
-      basket: this.context,
-      tags: [key],
-      include: 'entire transactions'
-    })
-    if (results.totalOutputs === 0) {
-      return // Key not found, do nothing
-    }
-    const pushdrop = new PushDrop(this.wallet, this.originator)
-    try {
-      const inputs: CreateActionInput[] = []
-      for (let i = 0; i < results.outputs.length; i++) {
-        inputs.push({
-          outpoint: results.outputs[i].outpoint,
-          unlockingScriptLength: 74,
-          inputDescription: 'Previous key-value token'
-        })
-      }
-      const { signableTransaction } = await this.wallet.createAction({
-        description: `Remove ${key} in ${this.context}`,
-        inputBEEF: results.BEEF,
-        inputs,
-        options: {
-          acceptDelayedBroadcast: false
-        }
-      })
-      if (typeof signableTransaction !== 'object') {
-        throw new Error('Wallet did not return a signable transaction when expected.')
-      }
-      const tx = Transaction.fromAtomicBEEF(signableTransaction.tx)
-      const spends: Record<number, SignActionSpend> = {}
-      for (let i = 0; i < results.outputs.length; i++) {
-        const unlocker = pushdrop.unlock(
-          [2, this.context],
-          key,
-          'self'
-        )
-        const unlockingScript = await unlocker.sign(tx, i)
-        spends[i] = {
-          unlockingScript: unlockingScript.toHex()
+  async remove(key: string): Promise<string[]> {
+    const txids: string[] = []
+    for (; ;) {
+      const { outputs, BEEF: inputBEEF, totalOutputs } = await this.getOutputs(key)
+      if (outputs.length > 0) {
+        const pushdrop = new PushDrop(this.wallet, this.originator)
+        try {
+          const inputs = this.getInputs(outputs)
+          const { signableTransaction } = await this.wallet.createAction({
+            description: `Remove ${key} in ${this.context}`,
+            inputBEEF,
+            inputs,
+            options: {
+              acceptDelayedBroadcast: false
+            }
+          })
+          if (typeof signableTransaction !== 'object') {
+            throw new Error('Wallet did not return a signable transaction when expected.')
+          }
+          const spends = await this.getSpends(key, outputs, pushdrop, signableTransaction.tx)
+          const { txid } = await this.wallet.signAction({
+            reference: signableTransaction.reference,
+            spends
+          })
+          txids.push(txid)
+        } catch (_) {
+          throw new Error(`There are ${totalOutputs} outputs with tag ${key} that cannot be unlocked.`)
         }
       }
-      const { txid } = await this.wallet.signAction({
-        reference: signableTransaction.reference,
-        spends
-      })
-      return txid
-    } catch (_) {
-      for (let i = 0; i < results.outputs.length; i++) {
-        await this.wallet.relinquishOutput({
-          output: results.outputs[i].outpoint,
-          basket: this.context
-        })
-      }
+      if (outputs.length === totalOutputs)
+        break;
     }
+    return txids
   }
 }

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -42,14 +42,14 @@ export default class LocalKVStore {
    * Creates an instance of the localKVStore.
    *
    * @param {WalletInterface} [wallet=new WalletClient()] - The wallet interface to use. Defaults to a new WalletClient instance.
-   * @param {string} [context='kvstoredefault'] - The context (basket) for namespacing keys. Defaults to 'kvstore-default'.
+   * @param {string} [context='kvstoredefault'] - The context (basket) for namespacing keys. Defaults to 'kvstore default'.
    * @param {boolean} [encrypt=true] - Whether to encrypt values. Defaults to true.
    * @param {string} [originator] — An originator to use with PushDrop and the wallet, if provided.
    * @throws {Error} If the context is missing or empty.
    */
   constructor (
     wallet: WalletInterface = new WalletClient(),
-    context = 'kvstoredefault',
+    context = 'kvstore default',
     encrypt = true,
     originator?: string
   ) {

--- a/src/kvstore/LocalKVStore.ts
+++ b/src/kvstore/LocalKVStore.ts
@@ -62,11 +62,11 @@ export default class LocalKVStore {
     this.originator = originator
   }
 
-  getProtocol (key: string): { protocolID: WalletProtocol, keyID: string } {
+  private getProtocol (key: string): { protocolID: WalletProtocol, keyID: string } {
     return { protocolID: [2, this.context], keyID: key }
   }
 
-  async getOutputs (key: string, limit?: number): Promise<ListOutputsResult> {
+  private async getOutputs (key: string, limit?: number): Promise<ListOutputsResult> {
     const results = await this.wallet.listOutputs({
       basket: this.context,
       tags: [key],
@@ -92,7 +92,7 @@ export default class LocalKVStore {
     return r.value
   }
 
-  getLockingScript (output: WalletOutput, beef: Beef): LockingScript {
+  private getLockingScript (output: WalletOutput, beef: Beef): LockingScript {
     const [txid, vout] = output.outpoint.split('.')
     const tx = beef.findTxid(txid)?.tx
     if (tx == null) { throw new Error(`beef must contain txid ${txid}`) }
@@ -100,7 +100,7 @@ export default class LocalKVStore {
     return lockingScript
   }
 
-  async lookupValue (key: string, defaultValue: string | undefined, limit?: number): Promise<LookupValueResult> {
+  private async lookupValue (key: string, defaultValue: string | undefined, limit?: number): Promise<LookupValueResult> {
     const lor = await this.getOutputs(key, limit)
     const r: LookupValueResult = { value: defaultValue, outpoint: undefined, lor }
     const { outputs } = lor
@@ -133,7 +133,7 @@ export default class LocalKVStore {
     return r
   }
 
-  getInputs (outputs: WalletOutput[]): CreateActionInput[] {
+  private getInputs (outputs: WalletOutput[]): CreateActionInput[] {
     const inputs: CreateActionInput[] = []
     for (let i = 0; i < outputs.length; i++) {
       inputs.push({
@@ -145,7 +145,7 @@ export default class LocalKVStore {
     return inputs
   }
 
-  async getSpends (key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> {
+  private async getSpends (key: string, outputs: WalletOutput[], pushdrop: PushDrop, atomicBEEF: AtomicBEEF): Promise<Record<number, SignActionSpend>> {
     const p = this.getProtocol(key)
     const tx = Transaction.fromAtomicBEEF(atomicBEEF)
     const spends: Record<number, SignActionSpend> = {}

--- a/src/wallet/WERR_REVIEW_ACTIONS.ts
+++ b/src/wallet/WERR_REVIEW_ACTIONS.ts
@@ -1,0 +1,30 @@
+import { AtomicBEEF, OutpointString, ReviewActionResult, SendWithResult, TXIDHexString } from './Wallet.interfaces.js'
+
+/**
+ * When a `createAction` or `signAction` is completed in undelayed mode (`acceptDelayedBroadcast`: false),
+ * any unsucccessful result will return the results by way of this exception to ensure attention is
+ * paid to processing errors.
+ */
+export class WERR_REVIEW_ACTIONS extends Error {
+  code: number
+  isError: boolean = true
+
+  /**
+   * All parameters correspond to their comparable `createAction` or `signSction` results
+   * with the exception of `reviewActionResults`;
+   * which contains more details, particularly for double spend results.
+   */
+  constructor (
+    public reviewActionResults: ReviewActionResult[],
+    public sendWithResults: SendWithResult[],
+    public txid?: TXIDHexString,
+    public tx?: AtomicBEEF,
+    public noSendChange?: OutpointString[]
+  ) {
+    super('Undelayed createAction or signAction results require review.')
+    this.code = 5
+    this.name = this.constructor.name
+  }
+}
+
+export default WERR_REVIEW_ACTIONS

--- a/src/wallet/Wallet.interfaces.ts
+++ b/src/wallet/Wallet.interfaces.ts
@@ -303,6 +303,30 @@ export interface SendWithResult {
   status: SendWithResultStatus
 }
 
+/**
+ * Indicates status of a new Action following a `createAction` or `signAction` in immediate mode:
+ * When `acceptDelayedBroadcast` is falses.
+ *
+ * 'success': The action has been broadcast and accepted by the bitcoin processing network.
+ * 'doulbeSpend': The action has been confirmed to double spend one or more inputs, and by the "first-seen-rule" is the loosing transaction.
+ * 'invalidTx': The action was rejected by the processing network as an invalid bitcoin transaction.
+ * 'serviceError': The broadcast services are currently unable to reach the bitcoin network. The action is now queued for delayed retries.
+ */
+export type ReviewActionResultStatus = 'success' | 'doubleSpend' | 'serviceError' | 'invalidTx'
+
+export interface ReviewActionResult {
+  txid: TXIDHexString
+  status: ReviewActionResultStatus
+  /**
+   * Any competing txids reported for this txid, valid when status is 'doubleSpend'.
+   */
+  competingTxs?: string[]
+  /**
+   * Merged beef of competingTxs, valid when status is 'doubleSpend'.
+   */
+  competingBeef?: number[]
+}
+
 export interface SignableTransaction {
   tx: AtomicBEEF
   reference: Base64String

--- a/src/wallet/WalletError.ts
+++ b/src/wallet/WalletError.ts
@@ -16,7 +16,7 @@ export class WalletError extends Error {
 }
 
 // NOTE: Enum values must not exceed the UInt8 range (0–255)
-enum walletErrors {
+export enum walletErrors {
   unknownError = 1,
   unsupportedAction = 2,
   invalidHmac = 3,
@@ -24,5 +24,6 @@ enum walletErrors {
   reviewActions = 5,
 }
 
-export default walletErrors
 export type WalletErrorCode = keyof typeof walletErrors
+
+export default WalletError

--- a/src/wallet/WalletError.ts
+++ b/src/wallet/WalletError.ts
@@ -21,6 +21,7 @@ enum walletErrors {
   unsupportedAction = 2,
   invalidHmac = 3,
   invalidSignature = 4,
+  reviewActions = 5,
 }
 
 export default walletErrors

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -3,6 +3,8 @@ export * from './KeyDeriver.js'
 export { default as CachedKeyDeriver } from './CachedKeyDeriver.js'
 export { default as ProtoWallet } from './ProtoWallet.js'
 export { default as WalletClient } from './WalletClient.js'
+// Is this an error? should it be 'walletErrors', the enum not the class?
 export { default as WalletErrors } from './WalletError.js'
+export { default as WERR_REVIEW_ACTIONS } from './WERR_REVIEW_ACTIONS.js'
 export * from './WalletError.js'
 export * from './substrates/index.js'

--- a/src/wallet/substrates/HTTPWalletJSON.ts
+++ b/src/wallet/substrates/HTTPWalletJSON.ts
@@ -33,8 +33,9 @@ import {
   SecurityLevel,
   SignActionArgs,
   SignActionResult,
-  VersionString7To30Bytes
+  VersionString7To30Bytes,
 } from '../Wallet.interfaces.js'
+import { WERR_REVIEW_ACTIONS } from '../WERR_REVIEW_ACTIONS.js'
 
 export default class HTTPWalletJSON implements WalletInterface {
   baseUrl: string
@@ -68,12 +69,17 @@ export default class HTTPWalletJSON implements WalletInterface {
 
       // Check the HTTP status on the original response
       if (!res.ok) {
-        const err = {
-          call,
-          args,
-          message: data.message ?? `HTTP Client error ${res.status}`
+        if (res.status === 400 && data.isError && data.code === 5) {
+          const err = new WERR_REVIEW_ACTIONS(data.reviewActionResults, data.sendWithResults, data.txid, data.tx, data.noSendChange)
+          throw err
+        } else {
+          const err = {
+            call,
+            args,
+            message: data.message ?? `HTTP Client error ${res.status}`
+          }
+          throw new Error(JSON.stringify(err))
         }
-        throw new Error(JSON.stringify(err))
       }
       return data
     }


### PR DESCRIPTION
tests pass, linted, doc, version 1.4.18, changelogged

Updated LocalKVStore

Added support for WERR_REVIEW_ACTIONS, an error thrown when createAction in immediate (non-delayed) mode encounters issues broadcasting new transactions (doubleSpend, invalidTx, serviceError/Unavailable).