### PR TITLE
make Beef verifyValid method public

### DIFF
--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -573,6 +573,10 @@ export class Beef {
     mergeBeef(beef: number[] | Beef): void 
     isValid(allowTxidOnly?: boolean): boolean 
     async verify(chainTracker: ChainTracker, allowTxidOnly?: boolean): Promise<boolean> 
+    verifyValid(allowTxidOnly?: boolean): {
+        valid: boolean;
+        roots: Record<number, string>;
+    } 
     toWriter(writer: Writer): void 
     toBinary(): number[] 
     toBinaryAtomic(txid: string): number[] 
@@ -947,6 +951,36 @@ Argument Details
 
 + **chainTracker**
   + Used to verify computed merkle path roots for all bump txids.
++ **allowTxidOnly**
+  + optional. If true, transaction txid is assumed valid
+
+#### Method verifyValid
+
+Sorts `txs` and confirms validity of transaction data contained in beef
+by validating structure of this beef.
+
+Returns block heights and merkle root values to be confirmed by a chaintracker.
+
+Validity requirements:
+1. No 'known' txids, unless `allowTxidOnly` is true.
+2. All transactions have bumps or their inputs chain back to bumps (or are known).
+3. Order of transactions satisfies dependencies before dependents.
+4. No transactions with duplicate txids.
+
+```ts
+verifyValid(allowTxidOnly?: boolean): {
+    valid: boolean;
+    roots: Record<number, string>;
+} 
+```
+
+Returns
+
+`valid` is true iff this Beef is structuraly valid.
+`roots` is a record where keys are block heights and values are the corresponding merkle roots to be validated.
+
+Argument Details
+
 + **allowTxidOnly**
   + optional. If true, transaction txid is assumed valid
 

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -2610,7 +2610,7 @@ The SDK is how applications communicate with wallets over a communications subst
 export default class WalletClient implements WalletInterface {
     public substrate: "auto" | WalletInterface;
     originator?: OriginatorDomainNameStringUnder250Bytes;
-    constructor(substrate: "auto" | "Cicada" | "XDM" | "window.CWI" | "json-api" | WalletInterface = "auto", originator?: OriginatorDomainNameStringUnder250Bytes) 
+    constructor(substrate: "auto" | "Cicada" | "XDM" | "window.CWI" | "json-api" | "react-native" | WalletInterface = "auto", originator?: OriginatorDomainNameStringUnder250Bytes) 
     async connectToSubstrate(): Promise<void> 
     async createAction(args: CreateActionArgs): Promise<CreateActionResult> 
     async signAction(args: SignActionArgs): Promise<SignActionResult> 

--- a/src/transaction/Beef.ts
+++ b/src/transaction/Beef.ts
@@ -391,7 +391,24 @@ export class Beef {
     return true
   }
 
-  private verifyValid (allowTxidOnly?: boolean): {
+  /**
+   * Sorts `txs` and confirms validity of transaction data contained in beef
+   * by validating structure of this beef.
+   *
+   * Returns block heights and merkle root values to be confirmed by a chaintracker.
+   *
+   * Validity requirements:
+   * 1. No 'known' txids, unless `allowTxidOnly` is true.
+   * 2. All transactions have bumps or their inputs chain back to bumps (or are known).
+   * 3. Order of transactions satisfies dependencies before dependents.
+   * 4. No transactions with duplicate txids.
+   *
+   * @param allowTxidOnly optional. If true, transaction txid is assumed valid
+   * @returns {{valid: boolean, roots: Record<number, string>}}
+   * `valid` is true iff this Beef is structuraly valid.
+   * `roots` is a record where keys are block heights and values are the corresponding merkle roots to be validated.
+   */
+  verifyValid (allowTxidOnly?: boolean): {
     valid: boolean
     roots: Record<number, string>
   } {


### PR DESCRIPTION
Makes existing Beef verifyValid method public (was private).

This method supports reorg handling by wallets that need to differentiate Beef structural validity from chaintracker validity.

Reorgs will cause Beefs to occasionally become invalid due to an orphaned block.
Wallets should opt to fix their own invalid data and throw a specific error when incoming merkle root data is invalid.