### PR TITLE
Add Reader/Writer benchmark

### DIFF
--- a/benchmarks/reader-writer.benchmark.js
+++ b/benchmarks/reader-writer.benchmark.js
@@ -1,0 +1,71 @@
+import { Writer, Reader } from '../dist/esm/src/primitives/utils.js'
+import BigNumber from '../dist/esm/src/primitives/BigNumber.js'
+
+function measure (fn) {
+  const start = process.hrtime.bigint()
+  fn()
+  const end = process.hrtime.bigint()
+  return Number(end - start) / 1e6 // ms
+}
+
+function createPayload (size) {
+  const arr = new Array(size)
+  for (let i = 0; i < size; i++) arr[i] = i & 0xff
+  return arr
+}
+
+function benchmarkLarge () {
+  const writer = new Writer()
+  const payload = createPayload(2 * 1024 * 1024)
+  for (let i = 0; i < 3; i++) writer.write(payload)
+  const data = writer.toArray()
+  const reader = new Reader(data)
+  for (let i = 0; i < 3; i++) reader.read(payload.length)
+}
+
+function benchmarkSmall () {
+  const writer = new Writer()
+  const payload = createPayload(100)
+  for (let i = 0; i < 3000; i++) writer.write(payload)
+  const data = writer.toArray()
+  const reader = new Reader(data)
+  for (let i = 0; i < 3000; i++) reader.read(payload.length)
+}
+
+function benchmarkMedium () {
+  const writer = new Writer()
+  const payload = createPayload(64 * 1024)
+  for (let i = 0; i < 100; i++) writer.write(payload)
+  const data = writer.toArray()
+  const reader = new Reader(data)
+  for (let i = 0; i < 100; i++) reader.read(payload.length)
+}
+
+function benchmarkMixed () {
+  const writer = new Writer()
+  for (let i = 0; i < 1000; i++) {
+    writer.writeUInt8(i & 0xff)
+    writer.writeInt16LE(i)
+    writer.writeUInt32BE(i)
+    writer.writeVarIntNum(i)
+    writer.writeUInt64LEBn(new BigNumber(i))
+  }
+  const data = writer.toArray()
+  const reader = new Reader(data)
+  for (let i = 0; i < 1000; i++) {
+    reader.readUInt8()
+    reader.readInt16LE()
+    reader.readUInt32BE()
+    reader.readVarIntNum()
+    reader.readUInt64LEBn()
+  }
+}
+
+function run () {
+  console.log('Large payloads:', measure(benchmarkLarge).toFixed(2), 'ms')
+  console.log('Small payloads:', measure(benchmarkSmall).toFixed(2), 'ms')
+  console.log('Medium payloads:', measure(benchmarkMedium).toFixed(2), 'ms')
+  console.log('Mixed payloads:', measure(benchmarkMixed).toFixed(2), 'ms')
+}
+
+run()

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,21 @@
+# Performance Benchmarks
+
+The following benchmarks exercise the `Reader` and `Writer` utilities on the `fix-mem` branch.
+Each scenario serializes data with `Writer`, deserializes with `Reader` and measures the total
+execution time using `process.hrtime`.
+
+| Case | Description | Time (ms) |
+|------|-------------|----------|
+| Large payloads | Three 2&nbsp;MB payloads written and read | 156.91 |
+| Small payloads | 3000 writes of a 100&nbsp;byte payload | 3.64 |
+| Medium payloads | One hundred 64&nbsp;KB payloads | 110.75 |
+| Mixed payloads | 1000 mixed integer operations | 7.76 |
+
+The benchmark can be run with:
+
+```bash
+npm run build
+node benchmarks/reader-writer.benchmark.js
+```
+
+Results may vary slightly between runs but provide a baseline for future optimisations.


### PR DESCRIPTION
## Summary
- add a deterministic benchmark for Reader and Writer
- document baseline timings in docs/performance.md

## Testing
- `npm test`
- `node benchmarks/reader-writer.benchmark.js`