### PR TITLE
Optimize BigInt ECDSA and hex conversion

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -41,6 +41,7 @@ node benchmarks/transaction-bench.js
 | Branch | deep chain verify | wide transaction verify | large tx verify | nested inputs verify |
 | --- | --- | --- | --- | --- |
 | fix-mem (May-2025) | 3335.76ms | 2930.86ms | 1534.36ms | 1198.08ms |
+| bigint optimizations | 2305.78ms | 2325.47ms | 1268.73ms | 859.70ms |
 
 ## SymmetricKey Encryption/Decryption
 

--- a/src/primitives/ECDSA.ts
+++ b/src/primitives/ECDSA.ts
@@ -512,16 +512,17 @@ export const verify = (msg: BigNumber, sig: Signature, key: Point): boolean => {
       k: bigint,
       P: { x: bigint, y: bigint }
     ): JacobianPoint => {
-      const N: JacobianPoint = { X: P.x, Y: P.y, Z: one }
+      let N: JacobianPoint = { X: P.x, Y: P.y, Z: one }
       let Q: JacobianPoint = { X: zero, Y: one, Z: zero } // Point at infinity
 
-      const kBin = k.toString(2)
-      for (let i = 0; i < kBin.length; i++) {
-        Q = pointDouble(Q)
-        if (kBin[i] === '1') {
-          Q = pointAdd(Q, N)
+      while (k > zero) {
+        if ((k & one) === one) {
+          Q = Q.Z === zero ? N : pointAdd(Q, N)
         }
+        N = pointDouble(N)
+        k >>= one
       }
+
       return Q
     }
 

--- a/src/primitives/Hash.ts
+++ b/src/primitives/Hash.ts
@@ -9,6 +9,17 @@ const assert = (
   }
 }
 
+// Lookup table for hexadecimal conversion
+const HEX_TABLE: number[] = (() => {
+  const table = new Array<number>(256).fill(0)
+  for (let i = 0; i < 10; i++) table[48 + i] = i
+  for (let i = 0; i < 6; i++) {
+    table[65 + i] = 10 + i
+    table[97 + i] = 10 + i
+  }
+  return table
+})()
+
 /**
  * The BaseHash class is an abstract base class for cryptographic hash functions.
  * It provides a common structure and functionality for hash function classes.
@@ -239,7 +250,7 @@ export function toArray (
   if (!(msg as unknown as boolean)) {
     return []
   }
-  const res = []
+  let res: number[] = []
   if (typeof msg === 'string') {
     if (enc !== 'hex') {
       // Inspired by stringToUtf8ByteArray() in closure-library by Google
@@ -267,12 +278,16 @@ export function toArray (
         }
       }
     } else {
-      msg = msg.replace(/[^a-z0-9]+/gi, '')
+      msg = msg.replace(/[^a-fA-F0-9]+/g, '')
       if (msg.length % 2 !== 0) {
         msg = '0' + msg
       }
-      for (let i = 0; i < msg.length; i += 2) {
-        res.push(parseInt(msg[i] + msg[i + 1], 16))
+      const len = msg.length / 2
+      res = new Array(len)
+      for (let i = 0, j = 0; j < len; j++, i += 2) {
+        const a = HEX_TABLE[msg.charCodeAt(i)]
+        const b = HEX_TABLE[msg.charCodeAt(i + 1)]
+        res[j] = (a << 4) | b
       }
     }
   } else {


### PR DESCRIPTION
## Summary
- add hex lookup table to speed up parsing
- streamline hex decoding loop
- replace string-based scalar multiplication in BigInt verifier
- document new benchmark numbers

## Testing
- `npm run test`
- `node benchmarks/transaction-bench.js`

------
https://chatgpt.com/codex/tasks/task_e_683b31d337ac832e80ed5ad159e8a339